### PR TITLE
Add activation button routine

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -143,6 +143,10 @@ module.exports = function Gruntfile( grunt ) {
 					'replace.browserextension.options.patterns',
 					[
 						{
+							match: 'jqueryInitialization',
+							replacement: grunt.file.read( 'src/singleton.activation.js' )
+						},
+						{
 							match: 'fullScript',
 							replacement: grunt.file.read( generatedFile )
 						},

--- a/build/template_browserextension.js
+++ b/build/template_browserextension.js
@@ -1,21 +1,10 @@
 ( function () {
 	var languageJson = @@languageBlob;
 	function loadWhoWroteThat() {
-		var interfaceLang = $( 'html' ).attr( 'lang' ),
-			$button = $( '<a>' )
-				.text( 'WhoWroteThat' )
-				.addClass( 'wwt-activationButton' )
-				.prependTo( '#p-personal' )
-				.click( onActivateButtonClick );
+		@@jqueryInitialization
 
-		// Load messages
-		mw.messages.set( $.extend(
-			// Make sure to fallback on English
-			languageJson.en,
-			languageJson[ interfaceLang ]
-		) );
-
-		// Attach button to DOM; jQuery is available
+		// Initialize
+		wwtActivationSingleton.initialize( languageJson, onActivateButtonClick );
 
 		function onActivateButtonClick( e ) {
 			mw.loader.using( [ 'oojs-ui' ] ).then( function () {
@@ -29,6 +18,6 @@
 	}
 
 	var q = window.RLQ || ( window.RLQ = [] );
-	q.push( [ [ 'jquery', 'mediawiki.base', 'mediawiki.jqueryMsg' ], loadWhoWroteThat ] );
+	q.push( [ [ 'jquery', 'mediawiki.base', 'mediawiki.util', 'mediawiki.jqueryMsg' ], loadWhoWroteThat ] );
 
 }() );

--- a/extension/js/generated.pageScript.js
+++ b/extension/js/generated.pageScript.js
@@ -1,21 +1,79 @@
 ( function () {
-	var languageJson = {"en":{"ext-whowrotethat-activation-link":"WhoWroteThat","ext-whowrotethat-activation-link-tooltip":"Activate WhoWroteThat"}};
+	var languageJson = {"en":{"ext-whowrotethat-activation-link":"Who Wrote That?","ext-whowrotethat-activation-link-tooltip":"Activate WhoWroteThat"}};
 	function loadWhoWroteThat() {
-		var interfaceLang = $( 'html' ).attr( 'lang' ),
-			$button = $( '<a>' )
-				.text( 'WhoWroteThat' )
-				.addClass( 'wwt-activationButton' )
-				.prependTo( '#p-personal' )
-				.click( onActivateButtonClick );
+		// eslint-disable-next-line no-unused-vars
+var wwtActivationSingleton = ( function () {
+	var originalHTML = $( '#bodyContent.mw-body-content' ).clone(),
+		interfaceLang = $( 'html' ).attr( 'lang' ),
+		/**
+		 * Initialize the activation button to toggle WhoWroteThat system.
+		 * Only attaches the button for pages in the main namespace, and only
+		 * in view mode.
+		 *
+		 * @param  {[type]} allTranslations An object representing all available
+		 *  translations, keyed by language code.
+		 * @param  {[type]} onClickFunction The function that is triggered when
+		 *  the activation button is clicked.
+		 */
+		initialize = function ( allTranslations, onClickFunction ) {
+			var link;
 
-		// Load messages
-		mw.messages.set( $.extend(
-			// Make sure to fallback on English
-			languageJson.en,
-			languageJson[ interfaceLang ]
-		) );
+			// Load all messages
+			mw.messages.set(
+				$.extend( {},
+					// Manually create fallback on English
+					allTranslations.en,
+					allTranslations[ interfaceLang ]
+				)
+			);
 
-		// Attach button to DOM; jQuery is available
+			// Add a portlet link to 'tools'
+			link = mw.util.addPortletLink(
+				'p-tb',
+				'#',
+				mw.msg( 'ext-whowrotethat-activation-link' ),
+				't-whowrotethat',
+				mw.msg( 'ext-whowrotethat-activation-link-tooltip' ),
+				'',
+				'#t-print'
+			);
+
+			// Attach event
+			$( link ).on( 'click', onClickFunction );
+		};
+
+	return {
+		/**
+		 * Get the original html of the article, for the purposes of toggling
+		 * the system on and off.
+		 *
+		 * @return {jQuery} Content node
+		 */
+		getOriginalHTML: function () {
+			return originalHTML;
+		},
+		initialize: function ( translations, onClickFunction ) {
+			// Bail out if we're anywhere that is not an article page in read mode
+			if (
+				// Not main namespace
+				mw.config.get( 'wgCanonicalNamespace' ) !== '' ||
+				// Not view screen
+				mw.config.get( 'wgAction' ) !== 'view' ||
+				// Is main page
+				mw.config.get( 'wgIsMainPage' )
+			) {
+				return;
+			}
+
+			// Otherwise, initialize
+			initialize( translations, onClickFunction );
+		}
+	};
+}() );
+
+
+		// Initialize
+		wwtActivationSingleton.initialize( languageJson, onActivateButtonClick );
 
 		function onActivateButtonClick( e ) {
 			mw.loader.using( [ 'oojs-ui' ] ).then( function () {
@@ -192,6 +250,6 @@ exports["default"] = _default;
 	}
 
 	var q = window.RLQ || ( window.RLQ = [] );
-	q.push( [ [ 'jquery', 'mediawiki.base', 'mediawiki.jqueryMsg' ], loadWhoWroteThat ] );
+	q.push( [ [ 'jquery', 'mediawiki.base', 'mediawiki.util', 'mediawiki.jqueryMsg' ], loadWhoWroteThat ] );
 
 }() );

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2,6 +2,6 @@
 	"@metadata": {
 		"authors": []
 	},
-	"ext-whowrotethat-activation-link": "WhoWroteThat",
+	"ext-whowrotethat-activation-link": "Who Wrote That?",
 	"ext-whowrotethat-activation-link-tooltip": "Activate WhoWroteThat"
 }

--- a/src/singleton.activation.js
+++ b/src/singleton.activation.js
@@ -1,0 +1,69 @@
+// eslint-disable-next-line no-unused-vars
+var wwtActivationSingleton = ( function () {
+	var originalHTML = $( '#bodyContent.mw-body-content' ).clone(),
+		interfaceLang = $( 'html' ).attr( 'lang' ),
+		/**
+		 * Initialize the activation button to toggle WhoWroteThat system.
+		 * Only attaches the button for pages in the main namespace, and only
+		 * in view mode.
+		 *
+		 * @param  {[type]} allTranslations An object representing all available
+		 *  translations, keyed by language code.
+		 * @param  {[type]} onClickFunction The function that is triggered when
+		 *  the activation button is clicked.
+		 */
+		initialize = function ( allTranslations, onClickFunction ) {
+			var link;
+
+			// Load all messages
+			mw.messages.set(
+				$.extend( {},
+					// Manually create fallback on English
+					allTranslations.en,
+					allTranslations[ interfaceLang ]
+				)
+			);
+
+			// Add a portlet link to 'tools'
+			link = mw.util.addPortletLink(
+				'p-tb',
+				'#',
+				mw.msg( 'ext-whowrotethat-activation-link' ),
+				't-whowrotethat',
+				mw.msg( 'ext-whowrotethat-activation-link-tooltip' ),
+				'',
+				'#t-print'
+			);
+
+			// Attach event
+			$( link ).on( 'click', onClickFunction );
+		};
+
+	return {
+		/**
+		 * Get the original html of the article, for the purposes of toggling
+		 * the system on and off.
+		 *
+		 * @return {jQuery} Content node
+		 */
+		getOriginalHTML: function () {
+			return originalHTML;
+		},
+		initialize: function ( translations, onClickFunction ) {
+			// Bail out if we're anywhere that is not an article page in read mode
+			if (
+				// Not main namespace
+				mw.config.get( 'wgCanonicalNamespace' ) !== '' ||
+				// Not view screen
+				mw.config.get( 'wgAction' ) !== 'view' ||
+				// Is main page
+				mw.config.get( 'wgIsMainPage' )
+			) {
+				return;
+			}
+
+			// Otherwise, initialize
+			initialize( translations, onClickFunction );
+		}
+	};
+}() );


### PR DESCRIPTION
**Depends on #15** Only merge this PR after #15 

- Create a singleton to handle the activation button
- Only add the button to main namespace in view mode
- Inject the button to the page with `mw.util.addPortletLink`

Task: https://phabricator.wikimedia.org/T226761