### PR TITLE
Add activation button process

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -163,6 +163,10 @@ module.exports = function Gruntfile( grunt ) {
 						'replace.' + which + '.options.patterns',
 						[
 							{
+								match: 'jqueryInitialization',
+								replacement: grunt.file.read( 'src/singleton.activation.js' )
+							},
+							{
 								match: 'fullScript',
 								replacement: grunt.file.read( generatedFile )
 							},

--- a/build/template_browserextension.js
+++ b/build/template_browserextension.js
@@ -1,21 +1,10 @@
 ( function () {
 	var languageJson = @@languageBlob;
 	function loadWhoWroteThat() {
-		var interfaceLang = $( 'html' ).attr( 'lang' ),
-			$button = $( '<a>' )
-				.text( 'WhoWroteThat' )
-				.addClass( 'wwt-activationButton' )
-				.prependTo( '#p-personal' )
-				.click( onActivateButtonClick );
+		@@jqueryInitialization
 
-		// Load messages
-		mw.messages.set( $.extend(
-			// Make sure to fallback on English
-			languageJson.en,
-			languageJson[ interfaceLang ]
-		) );
-
-		// Attach button to DOM; jQuery is available
+		// Initialize
+		wwtActivationSingleton.initialize( languageJson, onActivateButtonClick );
 
 		function onActivateButtonClick( e ) {
 			mw.loader.using( [ 'oojs-ui' ] ).then( function () {
@@ -23,12 +12,15 @@
 @@fullScript
 
 			} );
+
+			e.preventDefault();
+			return false;
 		}
 
 
 	}
 
 	var q = window.RLQ || ( window.RLQ = [] );
-	q.push( [ [ 'jquery', 'mediawiki.base', 'mediawiki.jqueryMsg' ], loadWhoWroteThat ] );
+	q.push( [ [ 'jquery', 'mediawiki.base', 'mediawiki.util', 'mediawiki.jqueryMsg' ], loadWhoWroteThat ] );
 
 }() );

--- a/build/template_gadget.js
+++ b/build/template_gadget.js
@@ -1,21 +1,10 @@
 ( function () {
 	var languageJson = @@languageBlob;
 	function loadWhoWroteThat() {
-		var interfaceLang = $( 'html' ).attr( 'lang' ),
-			$button = $( '<a>' )
-				.text( 'WhoWroteThat' )
-				.addClass( 'wwt-activationButton' )
-				.prependTo( '#p-personal' )
-				.click( onActivateButtonClick );
+		@@jqueryInitialization
 
-		// Load messages
-		mw.messages.set( $.extend(
-			// Make sure to fallback on English
-			languageJson.en,
-			languageJson[ interfaceLang ]
-		) );
-
-		// Attach button to DOM; jQuery is available
+		// Initialize
+		wwtActivationSingleton.initialize( languageJson, onActivateButtonClick );
 
 		function onActivateButtonClick( e ) {
 			mw.loader.using( [ 'oojs-ui' ] ).then( function () {
@@ -23,6 +12,9 @@
 @@fullScript
 
 			} );
+
+			e.preventDefault();
+			return false;
 		}
 
 

--- a/dist/extension/js/generated.pageScript.js
+++ b/dist/extension/js/generated.pageScript.js
@@ -1,21 +1,78 @@
 ( function () {
-	var languageJson = {"en":{"ext-whowrotethat-activation-link":"WhoWroteThat","ext-whowrotethat-activation-link-tooltip":"Activate WhoWroteThat"}};
+	var languageJson = {"en":{"ext-whowrotethat-activation-link":"Who Wrote That?","ext-whowrotethat-activation-link-tooltip":"Activate WhoWroteThat"}};
 	function loadWhoWroteThat() {
-		var interfaceLang = $( 'html' ).attr( 'lang' ),
-			$button = $( '<a>' )
-				.text( 'WhoWroteThat' )
-				.addClass( 'wwt-activationButton' )
-				.prependTo( '#p-personal' )
-				.click( onActivateButtonClick );
+		// eslint-disable-next-line no-unused-vars
+var wwtActivationSingleton = ( function () {
+	var $parserOutput = $( '.mw-parser-output' ),
+		$parserOutputStored = $parserOutput.clone(),
+		interfaceLang = $( 'html' ).attr( 'lang' ),
+		/**
+		 * Initialize the activation button to toggle WhoWroteThat system.
+		 * Only attaches the button for pages in the main namespace, and only
+		 * in view mode.
+		 *
+		 * @param  {[type]} allTranslations An object representing all available
+		 *  translations, keyed by language code.
+		 * @param  {[type]} onClickFunction The function that is triggered when
+		 *  the activation button is clicked.
+		 */
+		initialize = function ( allTranslations, onClickFunction ) {
+			var link;
 
-		// Load messages
-		mw.messages.set( $.extend(
-			// Make sure to fallback on English
-			languageJson.en,
-			languageJson[ interfaceLang ]
-		) );
+			// Load all messages
+			mw.messages.set(
+				$.extend( {},
+					// Manually create fallback on English
+					allTranslations.en,
+					allTranslations[ interfaceLang ]
+				)
+			);
 
-		// Attach button to DOM; jQuery is available
+			// Add a portlet link to 'tools'
+			link = mw.util.addPortletLink(
+				'p-tb',
+				'#',
+				mw.msg( 'ext-whowrotethat-activation-link' ),
+				't-whowrotethat',
+				mw.msg( 'ext-whowrotethat-activation-link-tooltip' )
+			);
+
+			// Attach event
+			$( link ).on( 'click', onClickFunction );
+		};
+
+	return {
+		/**
+		 * Get the original html of the article, for the purposes of toggling
+		 * the system on and off.
+		 *
+		 * @return {jQuery} Content node
+		 */
+		getOriginalHTML: function () {
+			return $parserOutputStored;
+		},
+		initialize: function ( translations, onClickFunction ) {
+			// Bail out if we're anywhere that is not an article page in read mode
+			if (
+				// Does not have the needed parser content
+				!$parserOutput.length ||
+				// Not main namespace
+				mw.config.get( 'wgCanonicalNamespace' ) !== '' ||
+				// Is main page
+				mw.config.get( 'wgIsMainPage' )
+			) {
+				return;
+			}
+
+			// Otherwise, initialize
+			initialize( translations, onClickFunction );
+		}
+	};
+}() );
+
+
+		// Initialize
+		wwtActivationSingleton.initialize( languageJson, onActivateButtonClick );
 
 		function onActivateButtonClick( e ) {
 			mw.loader.using( [ 'oojs-ui' ] ).then( function () {
@@ -186,12 +243,15 @@ exports["default"] = _default;
 
 
 			} );
+
+			e.preventDefault();
+			return false;
 		}
 
 
 	}
 
 	var q = window.RLQ || ( window.RLQ = [] );
-	q.push( [ [ 'jquery', 'mediawiki.base', 'mediawiki.jqueryMsg' ], loadWhoWroteThat ] );
+	q.push( [ [ 'jquery', 'mediawiki.base', 'mediawiki.util', 'mediawiki.jqueryMsg' ], loadWhoWroteThat ] );
 
 }() );

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2,6 +2,6 @@
 	"@metadata": {
 		"authors": []
 	},
-	"ext-whowrotethat-activation-link": "WhoWroteThat",
+	"ext-whowrotethat-activation-link": "Who Wrote That?",
 	"ext-whowrotethat-activation-link-tooltip": "Activate WhoWroteThat"
 }

--- a/src/singleton.activation.js
+++ b/src/singleton.activation.js
@@ -1,0 +1,68 @@
+// eslint-disable-next-line no-unused-vars
+var wwtActivationSingleton = ( function () {
+	var $parserOutput = $( '.mw-parser-output' ),
+		$parserOutputStored = $parserOutput.clone(),
+		interfaceLang = $( 'html' ).attr( 'lang' ),
+		/**
+		 * Initialize the activation button to toggle WhoWroteThat system.
+		 * Only attaches the button for pages in the main namespace, and only
+		 * in view mode.
+		 *
+		 * @param  {[type]} allTranslations An object representing all available
+		 *  translations, keyed by language code.
+		 * @param  {[type]} onClickFunction The function that is triggered when
+		 *  the activation button is clicked.
+		 */
+		initialize = function ( allTranslations, onClickFunction ) {
+			var link;
+
+			// Load all messages
+			mw.messages.set(
+				$.extend( {},
+					// Manually create fallback on English
+					allTranslations.en,
+					allTranslations[ interfaceLang ]
+				)
+			);
+
+			// Add a portlet link to 'tools'
+			link = mw.util.addPortletLink(
+				'p-tb',
+				'#',
+				mw.msg( 'ext-whowrotethat-activation-link' ),
+				't-whowrotethat',
+				mw.msg( 'ext-whowrotethat-activation-link-tooltip' )
+			);
+
+			// Attach event
+			$( link ).on( 'click', onClickFunction );
+		};
+
+	return {
+		/**
+		 * Get the original html of the article, for the purposes of toggling
+		 * the system on and off.
+		 *
+		 * @return {jQuery} Content node
+		 */
+		getOriginalHTML: function () {
+			return $parserOutputStored;
+		},
+		initialize: function ( translations, onClickFunction ) {
+			// Bail out if we're anywhere that is not an article page in read mode
+			if (
+				// Does not have the needed parser content
+				!$parserOutput.length ||
+				// Not main namespace
+				mw.config.get( 'wgCanonicalNamespace' ) !== '' ||
+				// Is main page
+				mw.config.get( 'wgIsMainPage' )
+			) {
+				return;
+			}
+
+			// Otherwise, initialize
+			initialize( translations, onClickFunction );
+		}
+	};
+}() );


### PR DESCRIPTION
- Create a singleton to handle the activation button
- Only add the button to main namespace in view mode, and not
  on the main page
- Inject the button to the page with `mw.util.addPortletLink`