### PR TITLE
Update command for grunt build in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ There's a Grunt job to output the code into a working browser extension. To test
 
 1. Clone the repo
 2. Run `npm install`
-3. Run `grunt build`
+3. Run `./node_modules/.bin/grunt build`
 4. Testing in Chrome: Go to `chrome://extensions/`, click on 'Load unpacked', and choose the `WhoWroteThat/dist/extension` directory. Enable the extension, and go to any article on en.wikipedia.org.
 5. Testing in Firefox: [Follow the official instructions](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Temporary_Installation_in_Firefox) to load `WhoWroteThat/dist/extension` directory as an unpacked addon. Enable, and go to any article on en.wikipedia.org.


### PR DESCRIPTION
`grunt build` I think assumes grunt is installed globally. Referencing the installed version from ./node_modules/.bin/ should work for any environment (assuming `npm build` was ran first).