### PR TITLE
Fix gadget call and remove test-only css

### DIFF
--- a/build/template_gadget.js
+++ b/build/template_gadget.js
@@ -20,5 +20,5 @@
 
 	}
 
-	loadWhoWroteThat();
+	$( document ).ready( loadWhoWroteThat );
 }() );

--- a/dist/extension/generated.whowrotethat.css
+++ b/dist/extension/generated.whowrotethat.css
@@ -2,6 +2,3 @@
  * Browser extension for WhoWroteThat 0.1.0
  * Wikimedia Foundation
  */
-body {
-  background-color: #ccc;
-}

--- a/dist/gadget/generated.pageScript.js
+++ b/dist/gadget/generated.pageScript.js
@@ -251,5 +251,5 @@ exports["default"] = _default;
 
 	}
 
-	loadWhoWroteThat();
+	$( document ).ready( loadWhoWroteThat );
 }() );

--- a/dist/gadget/generated.whowrotethat.css
+++ b/dist/gadget/generated.whowrotethat.css
@@ -16,6 +16,3 @@
  * `dist/gadget/generated.whowrotethat.js` and
  * `dist/gadget/generated.whowrotethat.css`
  */
-body {
-  background-color: #ccc;
-}

--- a/src/less/general.less
+++ b/src/less/general.less
@@ -1,3 +1,0 @@
-body {
-	background-color: #ccc; // Testing only!
-}


### PR DESCRIPTION
- Remove `body` css rule (was meant only for testing)
- For the gadget, only call the initialization after document-ready.