### PR TITLE
Remove jQuery dependency from extension initialization

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -128,8 +128,7 @@ module.exports = function Gruntfile( grunt ) {
 			browserextension: {
 				files: [
 					{ src: 'build/extension_manifest.json', dest: 'dist/extension/manifest.json' },
-					{ src: 'build/extension_content_script.js', dest: 'dist/extension/js/contentScript.js' },
-					{ src: 'node_modules/jquery/dist/jquery.min.js', dest: 'dist/extension/js/lib/jquery.js' }
+					{ src: 'build/extension_content_script.js', dest: 'dist/extension/js/contentScript.js' }
 				]
 			}
 		},

--- a/build/extension_content_script.js
+++ b/build/extension_content_script.js
@@ -1,20 +1,18 @@
-$( document ).ready( function () {
-	/**
-	 * injectScript - Inject internal script to available access to the `window`
-	 *
-	 * @param  {string} filePath Local path of the internal script.
-	 * @param  {string} tag The tag as string, where the script will be append (default: 'body').
-	 * @see    {@link http://stackoverflow.com/questions/20499994/access-window-variable-from-content-script}
-	 */
-	function injectScript( filePath, tag ) {
-		var node = document.getElementsByTagName( tag )[ 0 ],
-			script = document.createElement( 'script' );
+/**
+ * injectScript - Inject internal script to available access to the `window`
+ *
+ * @param  {string} filePath Local path of the internal script.
+ * @param  {string} tag The tag as string, where the script will be append (default: 'body').
+ * @see    {@link http://stackoverflow.com/questions/20499994/access-window-variable-from-content-script}
+ */
+function injectScript( filePath, tag ) {
+	var node = document.getElementsByTagName( tag )[ 0 ],
+		script = document.createElement( 'script' );
 
-		script.setAttribute( 'type', 'text/javascript' );
-		script.setAttribute( 'src', filePath );
-		node.appendChild( script );
-	}
+	script.setAttribute( 'type', 'text/javascript' );
+	script.setAttribute( 'src', filePath );
+	node.appendChild( script );
+}
 
-	// Inject page script into the DOM
-	injectScript( chrome.extension.getURL( 'js/generated.pageScript.js' ), 'body' );
-} );
+// Inject page script into the DOM
+injectScript( chrome.extension.getURL( 'js/generated.pageScript.js' ), 'body' );

--- a/build/extension_manifest.json
+++ b/build/extension_manifest.json
@@ -14,7 +14,7 @@
 			"*://es.wikipedia.org/*"
 		],
 		"all_frames": true,
-		"js": [ "js/lib/jquery.js", "js/contentScript.js" ],
+		"js": [ "js/contentScript.js" ],
 		"css": [ "generated.whowrotethat.css" ],
 		"run_at": "document_end"
 	} ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -5699,11 +5699,6 @@
          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
          "dev": true
       },
-      "jquery": {
-         "version": "3.3.1",
-         "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-         "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
-      },
       "js-levenshtein": {
          "version": "1.1.6",
          "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
       "build": "grunt build"
    },
    "dependencies": {
-      "jquery": "3.3.1",
       "@babel/polyfill": "^7.0.0"
    },
    "devDependencies": {


### PR DESCRIPTION
We actually don't need jQuery in the extension dependencies.
We are injecting the full script into the MediaWiki DOM, and use
the jquery that exists within that ecosystem. Our 'inject' mechanism
doesn't require jQuery itself, so there's no need to load jQuery
in the manifest.json.