### PR TITLE
Add welcome popup for first-time use

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,8 @@
         "$": false,
         "mw": false,
         "OO": false,
-        "chrome": false
+        "chrome": false,
+        "browser": false
     },
     "parserOptions": {
         "sourceType": "module"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -105,6 +105,13 @@ module.exports = function Gruntfile( grunt ) {
 				options: {
 					transform: [ 'babelify' ]
 				}
+			},
+			browserextensionTour: {
+				src: 'src/outputs/browserextension_tour.js',
+				dest: 'dist/extension/js/generated.welcomeTour.js',
+				options: {
+					transform: [ 'babelify' ]
+				}
 			}
 		},
 		replace: {

--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ There's a Grunt job to output the code into a working browser extension. To test
 3. Run `./node_modules/.bin/grunt build`
 4. Testing in Chrome: Go to `chrome://extensions/`, click on 'Load unpacked', and choose the `WhoWroteThat/dist/extension` directory. Enable the extension, and go to any article on en.wikipedia.org.
 5. Testing in Firefox: [Follow the official instructions](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Temporary_Installation_in_Firefox) to load `WhoWroteThat/dist/extension` directory as an unpacked addon. Enable, and go to any article on en.wikipedia.org.
+
+## Debugging
+The extension and gadget expose a debugging namespace for testing purposes in `wwtDebug`. These commands can be run in the console and will work for both implementations (gadget and browser extension) on valid articles where the script loads.
+
+Available commands are:
+
+* `wwtDebug.resetWelcomePopup()`: Resets the value of the stored 'shown' state of the popup. This is useful in case the popup was dismissed (which means it will never appear again) and for testing purposes, we want to display it again. After confirmation in the console, the popup will be displayed on subsequent refresh of the page.

--- a/build/extension_content_script.js
+++ b/build/extension_content_script.js
@@ -1,3 +1,4 @@
+var theBrowser = chrome || browser;
 /**
  * injectScript - Inject internal script to available access to the `window`
  *
@@ -14,8 +15,53 @@ function injectScript( filePath, tag ) {
 	node.appendChild( script );
 }
 
+/**
+ * Consider whether to activate the initial welcome tour
+ * and listen to dismissal event if so. If dismissal event
+ * happened, store that state so the welcome tour is never
+ * shown again.
+ */
+function activateWelcomeTour() {
+	theBrowser.storage.sync.get( [ 'WelcomeTourSeen' ], function ( result ) {
+		window.console.log( 'WhoWroteThat extension: Checking WelcomeTourSeen (' + result.WelcomeTourSeen + ')' );
+		if ( result.WelcomeTourSeen ) {
+			return;
+		}
+
+		// Inject the welcome tour script
+		window.console.log( 'WhoWroteThat extension: Injecting welcome tour' );
+		injectScript( theBrowser.extension.getURL( 'js/generated.welcomeTour.js' ), 'body' );
+	} );
+}
+
+// Add a listener for the DOM operations
+window.addEventListener( 'message', function ( event ) {
+	if ( event.source !== window ) {
+		return;
+	}
+
+	if (
+		event.data &&
+		event.data.from === 'whowrotethat'
+	) {
+		// Welcome popup
+		if ( event.data.type === 'tour-welcome' ) {
+			// Set the variable according to the action
+			theBrowser.storage.sync.set( {
+				// For 'dismiss', set true; for 'reset', set false
+				WelcomeTourSeen: event.data.action === 'dismiss'
+			}, function () {
+				window.console.log( 'WhoWroteThat Extension: Welcome tour dismissed.' );
+			} );
+		}
+	}
+}, false );
+
 // Write to console, for later debugging and bug filtering process for the extension
 window.console.info( 'WhoWroteThat Extension: Loaded on page.' );
 
 // Inject page script into the DOM
-injectScript( chrome.extension.getURL( 'js/generated.pageScript.js' ), 'body' );
+injectScript( theBrowser.extension.getURL( 'js/generated.pageScript.js' ), 'body' );
+
+// Activate welcome tour
+activateWelcomeTour();

--- a/build/extension_manifest.json
+++ b/build/extension_manifest.json
@@ -30,6 +30,11 @@
 		"css": [ "generated.whowrotethat.css" ],
 		"run_at": "document_end"
 	} ],
-	"web_accessible_resources": [ "js/generated.pageScript.js" ],
-	"permissions": [ "activeTab" ]
+	"web_accessible_resources": [ "js/generated.pageScript.js", "js/generated.welcomeTour.js" ],
+	"permissions": [ "activeTab", "storage" ],
+	"browser_specific_settings": {
+		"gecko": {
+			"id": "whowrotethat@wikimedia"
+		}
+	}
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -11,5 +11,9 @@
 	"ext-whowrotethat-error-contact": "Please $1 about this issue.",
 	"ext-whowrotethat-error-contact-link": "contact us",
 	"ext-whowrotethat-ready-title": "Who Wrote That?",
-	"ext-whowrotethat-ready-general": "Hover to see contributions by the same author. Click for more details."
+	"ext-whowrotethat-ready-general": "Hover to see contributions by the same author. Click for more details.",
+	"ext-whowrotethat-tour-welcome-title": "<strong><em>Who Wrote That?</em></strong> is enabled!",
+	"ext-whowrotethat-tour-welcome-description": "Activate the the tool from the sidebar. Hover over the text to see the author and their other contributions to this page. Click to get more details.",
+	"ext-whowrotethat-tour-welcome-dismiss": "Got it!"
+
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -11,5 +11,8 @@
 	"ext-whowrotethat-error-contact": "Error message shown if an error is unlikely to be recoverable, with a link to the Who Wrote That contact page.\n* $1 is the HTML link to the contact page, with the text specified in {{wm-msg|ext-whowrotethat-state-error-contact-link}}",
 	"ext-whowrotethat-error-contact-link": "The text of the link to the contact page shown in {{wm-msg|ext-whowrotethat-state-error-contact}}.",
 	"ext-whowrotethat-ready-title": "Title of the extension that appears when the system is loaded and displays information about the selection.",
-	"ext-whowrotethat-ready-general": "Instruction label that appears when the system is ready, before any hover or selection was made yet."
+	"ext-whowrotethat-ready-general": "Instruction label that appears when the system is ready, before any hover or selection was made yet.",
+	"ext-whowrotethat-tour-welcome-title": "The title for the welcome popup that appears when the extension is enabled for the first time, notifying the user it was installed successfully.",
+	"ext-whowrotethat-tour-welcome-description": "The description for the welcome popup that appears when the extension is enabled for the first time, explaining the activation and base usage of the extension.",
+	"ext-whowrotethat-tour-welcome-dismiss": "Button to permanently dismiss the welcome popup that appears when the extension is enabled for the first time."
 }

--- a/src/WelcomePopupWidget.js
+++ b/src/WelcomePopupWidget.js
@@ -1,0 +1,54 @@
+/**
+ * A popup meant to display as a welcome message after the
+ * extension is installed for the first time.
+ * @class
+ *
+ * @constructor
+ * @param {Object} [config={}] Configuration options
+ */
+const WelcomePopupWidget = function WelcomePopupWidget( config = {} ) {
+	const $content = $( '<div>' )
+		.addClass( 'ext-wwt-welcomePopupWidget-content' );
+
+	// Parent constructor
+	WelcomePopupWidget.parent.call( this, Object.assign(
+		{
+			padded: true,
+			autoClose: true,
+			position: 'after',
+			hideWhenOutOfView: false,
+			$content: $content
+		},
+		config
+	) );
+
+	this.dismissButton = new OO.ui.ButtonWidget( {
+		flags: [ 'primary', 'progressive' ],
+		label: mw.msg( 'ext-whowrotethat-tour-welcome-dismiss' )
+	} );
+
+	$content.append(
+		$( '<div>' )
+			.addClass( 'ext-wwt-welcomePopupWidget-title' )
+			.append( mw.msg( 'ext-whowrotethat-tour-welcome-title' ) ),
+		$( '<div>' )
+			.addClass( 'ext-wwt-welcomePopupWidget-description' )
+			.append( mw.msg( 'ext-whowrotethat-tour-welcome-description' ) ),
+		$( '<div>' )
+			.addClass( 'ext-wwt-welcomePopupWidget-button' )
+			.append( this.dismissButton.$element )
+	);
+
+	// Events
+	this.dismissButton.connect( this, { click: [ 'emit', 'dismiss' ] } );
+
+	// Initialize
+	this.$element
+		.addClass( 'ext-wwt-welcomePopupWidget' );
+};
+
+/* Setup */
+OO.inheritClass( WelcomePopupWidget, OO.ui.PopupWidget );
+
+module.exports = WelcomePopupWidget;
+export default WelcomePopupWidget;

--- a/src/less/WelcomePopupWidget.less
+++ b/src/less/WelcomePopupWidget.less
@@ -1,0 +1,13 @@
+.ext-wwt-welcomePopupWidget {
+	&-title {
+		margin-bottom: 1em;
+	}
+
+	&-button {
+		text-align: right;
+
+		.rtl& {
+			text-align: left;
+		}
+	}
+}

--- a/src/less/general.less
+++ b/src/less/general.less
@@ -1,3 +1,9 @@
 .mw-parser-output .editor-token.active {
 	background-color: #facc48;
 }
+
+.ext-wwt-overlay {
+	position: absolute;
+	top: 0;
+	left: 0;
+}

--- a/src/less/index.less
+++ b/src/less/index.less
@@ -1,2 +1,3 @@
 @import 'general';
 @import 'InfoBarWidget';
+@import 'WelcomePopupWidget';

--- a/src/outputs/browserextension.js
+++ b/src/outputs/browserextension.js
@@ -29,4 +29,16 @@ import languageBlob from '../../temp/languages'; // This is generated during the
 
 	var q = window.RLQ || ( window.RLQ = [] );
 	q.push( [ [ 'jquery', 'mediawiki.base', 'mediawiki.util', 'mediawiki.jqueryMsg' ], loadWhoWroteThat ] );
+
+	// For debugging purposes, export methods to the window global
+	window.wwtDebug = {
+		resetWelcomePopup: () => {
+			// Notify the extension
+			window.postMessage( {
+				from: 'whowrotethat',
+				type: 'tour-welcome',
+				action: 'reset'
+			}, '*' );
+		}
+	};
 }() );

--- a/src/outputs/browserextension_tour.js
+++ b/src/outputs/browserextension_tour.js
@@ -1,0 +1,44 @@
+( function () {
+	function loadWhoWroteThatWelcomeTour() {
+		$.when(
+			$.ready,
+			mw.loader.using( [
+				'oojs-ui',
+				'mediawiki.jqueryMsg'
+			] )
+		).then( function () {
+			if ( !$( '#t-whowrotethat' ).length ) {
+				return;
+			}
+
+			// Only load after dependencies are loaded
+			const $overlay = $( '<div>' ).addClass( 'ext-wwt-overlay' ),
+				WelcomePopupWidget = require( '../WelcomePopupWidget' ),
+				welcome = new WelcomePopupWidget( {
+					$floatableContainer: $( '#t-whowrotethat' ),
+					$overlay
+				} );
+
+			welcome.on( 'dismiss', function () {
+				// Notify the extension
+				window.postMessage( {
+					from: 'whowrotethat',
+					type: 'tour-welcome',
+					action: 'dismiss'
+				}, '*' );
+
+				// Hide the popup
+				welcome.toggle( false );
+			} );
+
+			// Show the popup
+			$( 'body' ).append( $overlay );
+			$overlay.append( welcome.$element );
+			welcome.toggle( true );
+		} );
+	}
+
+	// eslint-disable-next-line vars-on-top
+	var q = window.RLQ || ( window.RLQ = [] );
+	q.push( [ [ 'jquery', 'mediawiki.base' ], loadWhoWroteThatWelcomeTour ] );
+}() );


### PR DESCRIPTION
- Add a welcome popup when the extension is active for the first time
- Only show if the popup was not previously dismissed
  - For the extension, the popup script is only injected at all if it is needed and used.
  - For the gadget, the script is included but the popup is only triggered if it was not previously dismissed.
- Store dismissed state:
  - For the extension, use browser global storage
  - For the gadget, use localStorage
- Add a debugging namespace `wwtDebug`, with a method that allows for resetting the state of the popup dismissal for testing.
- Update the README.md file to show the new `wwtDebug` usage