### PR TITLE
Extension: Exclude special pages and log to console

### DIFF
--- a/build/extension_content_script.js
+++ b/build/extension_content_script.js
@@ -14,5 +14,8 @@ function injectScript( filePath, tag ) {
 	node.appendChild( script );
 }
 
+// Write to console, for later debugging and bug filtering process for the extension
+window.console.info( 'WhoWroteThat Extension: Loaded on page.' );
+
 // Inject page script into the DOM
 injectScript( chrome.extension.getURL( 'js/generated.pageScript.js' ), 'body' );

--- a/build/extension_manifest.json
+++ b/build/extension_manifest.json
@@ -13,6 +13,18 @@
 			"*://tr.wikipedia.org/*",
 			"*://es.wikipedia.org/*"
 		],
+		"exclude_globs": [
+			"*://en.wikipedia.org/wiki/Special:*",
+			"*://de.wikipedia.org/wiki/Spezial:*",
+			"*://eu.wikipedia.org/wiki/Berezi:*",
+			"*://tr.wikipedia.org/wiki/Özel:*",
+			"*://es.wikipedia.org/wiki/Especial:*",
+			"*://en.wikipedia.org/*title=Special:*",
+			"*://de.wikipedia.org/*title=Spezial:*",
+			"*://eu.wikipedia.org/*title=Berezi:*",
+			"*://tr.wikipedia.org/*title=Özel:*",
+			"*://es.wikipedia.org/*title=Especial:*"
+		],
 		"all_frames": true,
 		"js": [ "js/contentScript.js" ],
 		"css": [ "generated.whowrotethat.css" ],


### PR DESCRIPTION
Make sure the extension itself is not loading in any special page.
The code is already there to make the button not appear, but it is
best if the browser knows not to load the extension files at all
for excluded namespaces. The biggest and most problematic namespace
is the `Special:` namespace, that includes within it pages like
`Special:Login` and `Special:Preferences` where we don't want the
code to load at all.

In the case of a gadget, the MediaWiki system knows not to load
the gadget on "sensitive" pages (like `Special:Preferences` and
`Special:Login`) so those, at least, are covered, and the code
itself verifies that the button is not injected into the DOM in
pages that are not articles.