### PR TITLE
Run eslint on build rather than dist

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,7 +51,7 @@ module.exports = function Gruntfile( grunt ) {
 					'!temp/**',
 					'!test/**',
 					'test/suite/**',
-					'dist/extension/js/contentScript.js'
+					'build/extension_content_script.js'
 				]
 			}
 		},


### PR DESCRIPTION
To ensure that the content script is lintable where it's being
changed rather than where it's copied to.