### PR TITLE
Only load welcome popup on valid pages

### DIFF
--- a/src/ActivationSingleton.js
+++ b/src/ActivationSingleton.js
@@ -34,8 +34,6 @@ class ActivationSingleton {
 	 */
 	isValidPage() {
 		return !!(
-			// Initialization did not already happen
-			!this.initialized &&
 			// Has the needed parser content
 			this.$contentWrapper.length &&
 			// Is in the main namespace
@@ -78,7 +76,7 @@ class ActivationSingleton {
 	initialize( $content, config ) {
 		this.setProperties( $content, config );
 
-		if ( !this.isValidPage() ) {
+		if ( this.initialized || !this.isValidPage() ) {
 			return;
 		}
 

--- a/src/outputs/browserextension_tour.js
+++ b/src/outputs/browserextension_tour.js
@@ -7,6 +7,9 @@
 				'mediawiki.jqueryMsg'
 			] )
 		).then( function () {
+			// The check about whether the tour was already seen has already
+			// taken place at this point. This whole file would not be injected
+			// by the contentScript to begin with, if WelcomeTourSeen is true
 			if ( !$( '#t-whowrotethat' ).length ) {
 				return;
 			}

--- a/src/outputs/gadget.js
+++ b/src/outputs/gadget.js
@@ -33,8 +33,9 @@ import languageBlob from '../../temp/languages'; // This is generated during the
 
 		loadWhoWroteThat();
 
-		if ( welcomeTourSeen ) {
+		if ( welcomeTourSeen || !activationInstance.isValidPage() ) {
 			// Do not show the tour if it was previously dismissed
+			// Or if the page is invalid
 			return;
 		}
 


### PR DESCRIPTION
While the extension only actually loads on valid pages, there are
cases (like talk page and history, etc) where the files themselves
are loaded but the script won't when the activation singleton
checks for valid pages.

However, that check is only done for initialization of the main
script, and not for the welcome popup.

More importantly, the gadget always loads the welcome popup, and
we have to make sure it does not run or display it for invalid
pages since the validity check was only done for the activation
initialization of the general script.

This commit adds that check to the welcome popup as well, so it
does not load if the page is not valid.