### PR TITLE
WelcomePopup: Fix positioning problem for long pages

### DIFF
--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -34,7 +34,8 @@
         "jQuery": "https://api.jquery.com/Types/#jQuery",
         "jQuery.Promise": "https://api.jquery.com/Types/#Promise",
         "Object": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
-        "Promise": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
+        "Promise": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise",
+        "OO.ui.PopupWidget": "https://doc.wikimedia.org/oojs-ui/master/js/#!/api/OO.ui.PopupWidget"
       }
     }
   }

--- a/src/WelcomePopupWidget.js
+++ b/src/WelcomePopupWidget.js
@@ -2,6 +2,7 @@
  * A popup meant to display as a welcome message after the
  * extension is installed for the first time.
  * @class
+ * @extends OO.ui.PopupWidget
  *
  * @constructor
  * @param {Object} [config={}] Configuration options
@@ -49,6 +50,24 @@ const WelcomePopupWidget = function WelcomePopupWidget( config = {} ) {
 
 /* Setup */
 OO.inheritClass( WelcomePopupWidget, OO.ui.PopupWidget );
+
+/* Methods */
+
+/**
+ * @inheritdoc
+ */
+WelcomePopupWidget.prototype.toggle = function ( show ) {
+	// Parent method
+	WelcomePopupWidget.parent.prototype.toggle.call( this, show );
+
+	// HACK: Prevent clipping; we don't want (or need) the
+	// popup to clip itself when it's outside the viewport
+	// or close to the viewport.
+	// Unfortunately, the toggle operation calls toggleClipping
+	// multiple times on and off, so we have to insist on it
+	// being actually off at the end of it.
+	this.toggleClipping( false );
+};
 
 module.exports = WelcomePopupWidget;
 export default WelcomePopupWidget;

--- a/src/less/general.less
+++ b/src/less/general.less
@@ -1,3 +1,13 @@
+html.ext-wwt-popup,
+html.ext-wwt-popup body {
+	// HACK: By default, the html and <body> only span
+	// as far down as the viewport, even though the content
+	// is longer. This makes the welcome popup appear in
+	// weird places if the "Tools" menu is beyond the bottom
+	// of the viewport itself.
+	height: unset;
+}
+
 .mw-parser-output .editor-token {
 	cursor: pointer;
 

--- a/src/outputs/browserextension_tour.js
+++ b/src/outputs/browserextension_tour.js
@@ -35,6 +35,7 @@
 			} );
 
 			// Show the popup
+			$( 'html' ).addClass( 'ext-wwt-popup' );
 			$( 'body' ).append( $overlay );
 			$overlay.append( welcome.$element );
 			welcome.toggle( true );

--- a/src/outputs/gadget.js
+++ b/src/outputs/gadget.js
@@ -64,6 +64,7 @@ import languageBlob from '../../temp/languages'; // This is generated during the
 			} );
 
 			// Show the popup
+			$( 'html' ).addClass( 'ext-wwt-popup' );
 			$( 'body' ).append( $overlay );
 			$overlay.append( welcome.$element );
 			welcome.toggle( true );


### PR DESCRIPTION
When we have long pages where the "tools" menu is under the viewport,
the `<html>` tag, unhelpfully, stops (its height is limited) at the
edge of the viewport. This means that the `<body>` is similarly limited
in height, even though the content itself keeps going.

As a result, the popup, when instantiated, cannot be placed below
that point, which creates a popup that appears above where it should.

This is a hacky way to fix this. When and if the popup is active,
the code adds a class to the `html` block and sets it at a large
min-height that will cover at least the side menu to be able to
get the popup to appear properly.

HTML sucks.