### PR TITLE
Fix to make the click event use the correct target for thumbnails

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -128,7 +128,7 @@ class App {
 				if ( this.revisionPopup.isVisible() ) {
 					return;
 				}
-				const ids = this.api.getIdsFromElement( e.target );
+				const ids = this.api.getIdsFromElement( e.currentTarget );
 				this.activateSpans( ids.editorId );
 			} )
 			.on( 'mouseleave', () => {
@@ -139,10 +139,10 @@ class App {
 			} );
 
 		$( '.editor-token' ).on( 'click', e => {
-			const ids = this.api.getIdsFromElement( e.target ),
+			const ids = this.api.getIdsFromElement( e.currentTarget ),
 				tokenInfo = this.api.getTokenInfo( ids.tokenId );
 			this.activateSpans( ids.editorId );
-			this.revisionPopup.show( tokenInfo, $( e.target ) );
+			this.revisionPopup.show( tokenInfo, $( e.currentTarget ) );
 			this.revisionPopup.once( 'toggle', this.deactivateSpans );
 
 			// Fetch edit summary then re-render the popup.

--- a/src/RevisionPopupWidget.js
+++ b/src/RevisionPopupWidget.js
@@ -63,6 +63,11 @@ RevisionPopupWidget.prototype.show = function ( data, $target ) {
 		html = $.parseHTML( `${addedMsg.trim()} ${commentMsg}${sizeMsg} ${attributionMsg}` );
 
 	$( '.ext-wwt-revisionPopupWidget-content' ).html( html );
+
+	if ( $target.find( '.thumb' ).length ) {
+		$target = $target.find( '.thumb' );
+	}
+
 	this.setFloatableContainer( $target );
 	this.toggle( true );
 };


### PR DESCRIPTION
Thumbnail images are tokenized but are usually floated to the left or
right, meaning the element that triggered the event may differ from the
visible element that triggered the event (the one with the token ID).
Additionally, we need to attach the popup to the thumbnail itself.

Bug: T231959