### PR TITLE
Fix display and links for IPs

### DIFF
--- a/src/RevisionPopupWidget.js
+++ b/src/RevisionPopupWidget.js
@@ -21,17 +21,22 @@ OO.inheritClass( RevisionPopupWidget, OO.ui.PopupWidget );
 
 /**
  * Show the revision popup based on the given token data, above the given element.
+ * Note that the English namespaces will normalize to the wiki's local namespaces.
  * @param {Object} data As returned by Api.getTokenInfo().
  * @param {jQuery} $target Element the popup should be attached to.
  */
 RevisionPopupWidget.prototype.show = function ( data, $target ) {
-	// Note that the English namespaces will normalize to the wiki's local namespaces.
-	const userLinks = `
-		<a target="_blank" href="${mw.util.getUrl( `User:${data.username}` )}">${data.username}</a>
-		${mw.msg( 'parentheses-start' )}<a target="_blank" href="${mw.util.getUrl( `User talk:${data.username}` )}">${mw.msg( 'talkpagelinktext' )}</a>
-		${mw.msg( 'pipe-separator' )}
-		<a target="_blank" href="${mw.util.getUrl( `Special:Contributions/${data.username}` )}">${mw.msg( 'contribslink' )}</a>${mw.msg( 'parentheses-end' )}
-	`,
+	const isIP = data.username.slice( 0, 2 ) === '0|',
+		username = isIP ? data.username.slice( 2 ) : data.username,
+		contribsUrl = mw.util.getUrl( `Special:Contributions/${username}` ),
+		// We typically link to Special:Contribs for IPs.
+		userPageUrl = isIP ? contribsUrl : mw.util.getUrl( `User:${data.username}` ),
+		userLinks = `
+			<a target="_blank" href="${userPageUrl}">${username}</a>
+			${mw.msg( 'parentheses-start' )}<a target="_blank" href="${mw.util.getUrl( `User talk:${username}` )}">${mw.msg( 'talkpagelinktext' )}</a>
+			${mw.msg( 'pipe-separator' )}
+			<a target="_blank" href="${contribsUrl}">${mw.msg( 'contribslink' )}</a>${mw.msg( 'parentheses-end' )}
+		`,
 		dateStr = moment( data.revisionTime ).locale( mw.config.get( 'wgUserLanguage' ) ).format( 'LLL' ),
 		diffLink = `<a target="_blank" href="${mw.util.getUrl( `Special:Diff/${data.revisionId}` )}">${dateStr}</a>`,
 		addedMsg = mw.message( 'ext-whowrotethat-revision-added', userLinks, diffLink ).parse(),


### PR DESCRIPTION
WikiWho prefixes IP contributions with "0|". We check for this and make
sure both the display of the username (IP) and the links are correct.

Bug: T231960