### PR TITLE
Only replace inner HTML of content element

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -141,7 +141,7 @@ class App {
 	onWidgetClose() {
 		// Close button; revert back to the original content
 		activationInstance.getContentWrapper()
-			.replaceWith( activationInstance.getOriginalContent() );
+			.html( activationInstance.getOriginalContent().html() );
 
 		// Hide the widget
 		this.widget.toggle( false );


### PR DESCRIPTION
Rather than replacing the whole element, which means that next
time we want to replace it it's no longer in the DOM, we just
replace the inner HTML. This assumes that WikiWho never wants
to add attributes to the containing div (which it doesn't).

Bug: T231417
