### PR TITLE
Add exit functionality

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4,6 +4,7 @@
 	},
 	"ext-whowrotethat-activation-link": "Who Wrote That?",
 	"ext-whowrotethat-activation-link-tooltip": "Activate Who Wrote That?",
+	"ext-whowrotethat-deactivation-link": "Close Who Wrote That?",
 	"ext-whowrotethat-state-pending": "<strong><em>Who Wrote That?</em></strong> is loading. This might take a while.",
 	"ext-whowrotethat-state-error": "API Error: $1",
 	"ext-whowrotethat-error-refresh": "Please refresh the page or try again later.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -2,8 +2,9 @@
 	"@metadata": {
 		"authors": []
 	},
-	"ext-whowrotethat-activation-link": "The text for the link that toggles WhoWroteThat mode",
-	"ext-whowrotethat-activation-link-tooltip": "The tooltip for the link that toggles WhoWroteThat mode",
+	"ext-whowrotethat-activation-link": "The text for the link that turns Who Wrote That on",
+	"ext-whowrotethat-activation-link-tooltip": "The tooltip for the link that turns Who Wrote That on",
+	"ext-whowrotethat-deactivation-link": "The text for the link that turns Who Wrote That off",
 	"ext-whowrotethat-state-pending": "Displays in the information bar during loading.",
 	"ext-whowrotethat-state-error": "Prefix for the error display in the information bar in case there were errors while loading.",
 	"ext-whowrotethat-error-refresh": "Error message shown when an error is probably recoverable.",

--- a/src/ActivationSingleton.js
+++ b/src/ActivationSingleton.js
@@ -109,6 +109,21 @@ class ActivationSingleton {
 	}
 
 	/**
+	 * Set the link text and tooltip.
+	 * @param {boolean} [active] The state to toggle to.
+	 */
+	toggleLink( active ) {
+		const anchor = this.link.querySelector( 'a' );
+		if ( active ) {
+			anchor.textContent = mw.msg( 'ext-whowrotethat-deactivation-link' );
+			anchor.title = '';
+		} else {
+			anchor.textContent = mw.msg( 'ext-whowrotethat-activation-link' );
+			anchor.title = mw.msg( 'ext-whowrotethat-activation-link-tooltip' );
+		}
+	}
+
+	/**
 	 * Load the required dependencies for the full script
 	 *
 	 * @return {jQuery.Promise} Promise that is resolved when

--- a/src/App.js
+++ b/src/App.js
@@ -71,12 +71,25 @@ class App {
 	 */
 	start() {
 		this.initialize();
+
+		// Close if already open.
+		if ( this.widget.isVisible() ) {
+			this.onWidgetClose();
+			return;
+		}
+
+		// Otherwise, proceed to open and fetch data.
 		this.widget.toggle( true );
+		activationInstance.toggleLink( true );
 
 		this.api.getData( window.location.href )
 			.then(
 				// Success handler.
 				() => {
+					// The widget might have been closed since getData began.
+					if ( !this.widget.isVisible() ) {
+						return;
+					}
 					// Insert modified HTML.
 					$( '.mw-parser-output' ).html( this.api.getReplacementHtml() );
 					$( 'body' ).append( this.revisionPopup.$element );
@@ -154,8 +167,9 @@ class App {
 		activationInstance.getContentWrapper()
 			.html( activationInstance.getOriginalContent().html() );
 
-		// Hide the widget
+		// Hide the widget and update the sidebar link.
 		this.widget.toggle( false );
+		activationInstance.toggleLink( false );
 	}
 }
 

--- a/src/InfoBarWidget.js
+++ b/src/InfoBarWidget.js
@@ -30,6 +30,7 @@ const InfoBarWidget = function InfoBarWidget( config = {} ) {
 
 	// Set properties
 	this.setState( config.state || 'pending' );
+	this.toggle( false );
 	this.setLabel( $( '<span>' ).append( mw.msg( 'ext-whowrotethat-state-pending' ) ).contents() );
 
 	// Close event
@@ -91,7 +92,6 @@ InfoBarWidget.prototype.setState = function ( state ) {
 
 		this.$pendingAnimation.toggle( state === 'pending' );
 		this.userInfoLabel.toggle( state === 'ready' );
-		this.closeIcon.toggle( state !== 'pending' );
 
 		this.state = state;
 	}


### PR DESCRIPTION
Make it possible to close WWT from the info bar while loading,
and from the sidebar link. The link-manipulating is contained
within ActivationSingleton because that's where it's being
created.

https://phabricator.wikimedia.org/T231359
Bug: T231359