### PR TITLE
Improve same-page linking

### DIFF
--- a/src/RevisionPopupWidget.js
+++ b/src/RevisionPopupWidget.js
@@ -49,24 +49,28 @@ RevisionPopupWidget.prototype.show = function ( data, $target ) {
 		// We typically link to Special:Contribs for IPs.
 		userPageUrl = isIP ? contribsUrl : mw.util.getUrl( `User:${data.username}` ),
 		userLinks = `
-			<a target="_blank" href="${userPageUrl}">${username}</a>
-			${mw.msg( 'parentheses-start' )}<a target="_blank" href="${mw.util.getUrl( `User talk:${username}` )}">${mw.msg( 'talkpagelinktext' )}</a>
+			<a href="${userPageUrl}">${username}</a>
+			${mw.msg( 'parentheses-start' )}<a href="${mw.util.getUrl( `User talk:${username}` )}">${mw.msg( 'talkpagelinktext' )}</a>
 			${mw.msg( 'pipe-separator' )}
-			<a target="_blank" href="${contribsUrl}">${mw.msg( 'contribslink' )}</a>${mw.msg( 'parentheses-end' )}
+			<a href="${contribsUrl}">${mw.msg( 'contribslink' )}</a>${mw.msg( 'parentheses-end' )}
 		`,
 		dateStr = moment( data.revisionTime ).locale( mw.config.get( 'wgUserLanguage' ) ).format( 'LLL' ),
-		diffLink = `<a target="_blank" href="${mw.util.getUrl( `Special:Diff/${data.revisionId}` )}">${dateStr}</a>`,
+		diffLink = `<a href="${mw.util.getUrl( `Special:Diff/${data.revisionId}` )}">${dateStr}</a>`,
 		addedMsg = mw.message( 'ext-whowrotethat-revision-added', userLinks, diffLink ).parse(),
 		commentMsg = data.comment ? `<span class="comment comment--without-parentheses ext-wwt-revisionPopupWidget-comment">${data.comment}</span>` : '',
 		sizeMsg = data.size ? getSizeHtml( data.size ) : '',
 		attributionMsg = `<div class="ext-wwt-revisionPopupWidget-attribution">${mw.message( 'ext-whowrotethat-revision-attribution', data.score ).parse()}</div>`,
+		$popupContent = $( '.ext-wwt-revisionPopupWidget-content' ),
 		html = $.parseHTML( `${addedMsg.trim()} ${commentMsg}${sizeMsg} ${attributionMsg}` );
 
-	$( '.ext-wwt-revisionPopupWidget-content' ).html( html );
+	$popupContent.html( html );
 
 	if ( $target.find( '.thumb' ).length ) {
 		$target = $target.find( '.thumb' );
 	}
+
+	// Make sure all links in the popup (including in the edit summary) open in new tabs.
+	$popupContent.find( 'a' ).attr( 'target', '_blank' );
 
 	this.setFloatableContainer( $target );
 	this.toggle( true );

--- a/src/less/general.less
+++ b/src/less/general.less
@@ -8,12 +8,18 @@ html.ext-wwt-popup body {
 	height: unset;
 }
 
+// Disable all links in the content area, other than in-page (fragment) links.
+.mw-parser-output.ext-wwt-enabled a {
+	pointer-events: none;
+
+	// Re-enable those with a href that start with a hash/pound/octothorpe.
+	&[ href^='\0023' ] {
+		pointer-events: auto;
+	}
+}
+
 .mw-parser-output .editor-token {
 	cursor: pointer;
-
-	a {
-		pointer-events: none;
-	}
 
 	&.active {
 		background-color: #facc48;


### PR DESCRIPTION
* Make sure section/citation link targets aren't obscured by the
  WhoWroteThat infobar, by adjusting scroll by the height of
  the bar.
* Add ext-wwt-enabled class to the parser-output element, so we
  can style links appropriately.
* Make all links in revision popups, including those in the edit
  summaries, open in new tabs.

Bug: T231595