### PR TITLE
Add web-ext for linting and building the extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,39 @@ The extension works only on Wikipedias supported by WhoColor API:
 
 ## Testing the Browser Extension
 
-There's a Grunt job to output the code into a working browser extension. To test it:
+There's a Grunt job to output the code into both a working browser extension and gadget.
 
-1. Clone the repo
+1. Clone the repo: `git clone https://github.com/wikimedia/whowrotethat.git`
+2. Go into its directory: `cd whowrotethat`
 2. Run `npm install`
-3. Run `npm run build`
-4. Testing in Chrome: Go to `chrome://extensions/`, click on 'Load unpacked', and choose the `WhoWroteThat/dist/extension` directory. Enable the extension, and go to any article on en.wikipedia.org.
-5. Testing in Firefox: [Follow the official instructions](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Temporary_Installation_in_Firefox) to load `WhoWroteThat/dist/extension` directory as an unpacked addon. Enable, and go to any article on en.wikipedia.org. 
+3.
+   * **Firefox:**
+      1. Run `grunt run`
+      2. This will open Firefox to a random page on English Wikipedia,
+         and you should have the 'Who Wrote That?' link in the sidebar.
+         See the [web-ext 'run' docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/web-ext_command_reference#web-ext_run)
+         for details of how to customize this command with environment variables.
+      3. If you want to [load the extension manually](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Temporary_Installation_in_Firefox),
+         go to `about:debugging` and select the manifest file in `dist/extension/`.
+   * **Chrome:**
+      1. Run `grunt build`
+      2. Go to `chrome://extensions/` in Chrome
+      3. Click on 'Load unpacked', and choose the `WhoWroteThat/dist/extension` directory
+      4. Enable the extension, and go to any article on en.wikipedia.org.
+   * **Wikipedia gadget or userscript:**
+      1. Run `grunt build`
+      2. Refer to [the install.md file](./tutorials/install.md).
 
-To install as a gadget, follow step 1-3 then refer to [the install.md file](./tutorials/install.md).
+## Releasing the browser extension
+
+After updating the version number in `package.json`
+and tagging the release in Git,
+run `grunt` (the default task only) to create
+a zip file such as `dist/whowrotethat_for_wikipedia-0.2.0.0.zip`.
+This can be uploaded to the Firefox and Chrome browser stores.
+
+A second zip file is also produced, containing the source code.
+This is required for submission to the Firefox add-ons store.
 
 ## Debugging
 

--- a/build/extension_manifest.json
+++ b/build/extension_manifest.json
@@ -2,9 +2,9 @@
 	"manifest_version": 2,
 	"name": "WhoWroteThat for Wikipedia",
 	"author": "Wikimedia Foundation",
-	"description": "",
-	"homepage_url": "https://github.com/wikimedia/WhoWroteThat",
-	"version": "0.0.1",
+	"description": "@@description",
+	"homepage_url": "https://meta.wikimedia.org/wiki/Community_Tech/Who_Wrote_That_tool",
+	"version": "@@version",
 	"icons": {
 		"48": "icons/icon-48.png",
 		"128": "icons/icon-128.png",
@@ -36,10 +36,5 @@
 		"run_at": "document_end"
 	} ],
 	"web_accessible_resources": [ "js/generated.pageScript.js", "js/generated.welcomeTour.js" ],
-	"permissions": [ "activeTab", "storage" ],
-	"browser_specific_settings": {
-		"gecko": {
-			"id": "whowrotethat@wikimedia"
-		}
-	}
+	"permissions": [ "activeTab", "storage" ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
    "name": "WhoWroteThat",
-   "version": "0.1.0",
+   "version": "0.2.0",
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {
@@ -821,6 +821,25 @@
             }
          }
       },
+      "@babel/runtime": {
+         "version": "7.6.2",
+         "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+         "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+         "dev": true,
+         "requires": {
+            "regenerator-runtime": "^0.13.2"
+         }
+      },
+      "@babel/runtime-corejs2": {
+         "version": "7.6.2",
+         "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.6.2.tgz",
+         "integrity": "sha512-wdyVKnTv9Be4YlwF/7pByYNfcl23qC21aAQ0aIaZOo2ZOvhFEyJdBLJClYZ9i+Pmrz7sUQgg/MwbJa2RZTkygg==",
+         "dev": true,
+         "requires": {
+            "core-js": "^2.6.5",
+            "regenerator-runtime": "^0.13.2"
+         }
+      },
       "@babel/template": {
          "version": "7.4.4",
          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
@@ -877,6 +896,42 @@
             "to-fast-properties": "^2.0.0"
          }
       },
+      "@cliqz-oss/firefox-client": {
+         "version": "0.3.1",
+         "resolved": "https://registry.npmjs.org/@cliqz-oss/firefox-client/-/firefox-client-0.3.1.tgz",
+         "integrity": "sha512-RO+Tops/wGnBzWoZYkCraqyh2JqOejqJq5/a4b54HhmjTNSKdUPwAOK17EGg/zPb0nWqkuB7QyZsI9bo+ev8Kw==",
+         "dev": true,
+         "requires": {
+            "colors": "0.5.x",
+            "js-select": "~0.6.0"
+         },
+         "dependencies": {
+            "colors": {
+               "version": "0.5.1",
+               "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+               "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
+               "dev": true
+            }
+         }
+      },
+      "@cliqz-oss/node-firefox-connect": {
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/@cliqz-oss/node-firefox-connect/-/node-firefox-connect-1.2.1.tgz",
+         "integrity": "sha512-O/IyiB5pfztCdmxQZg0/xeq5w+YiP3gtJz8d4We2EpLPKzbDVjOrtfLKYgVfm6Ya6mbvDge1uLkSRwaoVCWKnA==",
+         "dev": true,
+         "requires": {
+            "@cliqz-oss/firefox-client": "0.3.1",
+            "es6-promise": "^2.0.1"
+         },
+         "dependencies": {
+            "es6-promise": {
+               "version": "2.3.0",
+               "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+               "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw=",
+               "dev": true
+            }
+         }
+      },
       "@mrmlnc/readdir-enhanced": {
          "version": "2.2.1",
          "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -892,6 +947,21 @@
          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
          "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
          "dev": true
+      },
+      "@sindresorhus/is": {
+         "version": "0.14.0",
+         "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+         "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+         "dev": true
+      },
+      "@szmarczak/http-timer": {
+         "version": "1.1.2",
+         "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+         "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+         "dev": true,
+         "requires": {
+            "defer-to-connect": "^1.0.1"
+         }
       },
       "@types/events": {
          "version": "3.0.0",
@@ -948,6 +1018,12 @@
             "@types/node": "*",
             "@types/unist": "*"
          }
+      },
+      "JSONSelect": {
+         "version": "0.2.1",
+         "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.2.1.tgz",
+         "integrity": "sha1-QVQYpSbTP+MddLTe+jyDbUhewgM=",
+         "dev": true
       },
       "JSONStream": {
          "version": "1.3.5",
@@ -1026,6 +1102,317 @@
          "integrity": "sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg==",
          "dev": true
       },
+      "adbkit": {
+         "version": "2.11.1",
+         "resolved": "https://registry.npmjs.org/adbkit/-/adbkit-2.11.1.tgz",
+         "integrity": "sha512-hDTiRg9NX3HQt7WoDAPCplUpvzr4ZzQa2lq7BdTTJ/iOZ6O7YNAs6UYD8sFAiBEcYHDRIyq3cm9sZP6uZnhvXw==",
+         "dev": true,
+         "requires": {
+            "adbkit-logcat": "^1.1.0",
+            "adbkit-monkey": "~1.0.1",
+            "bluebird": "~2.9.24",
+            "commander": "^2.3.0",
+            "debug": "~2.6.3",
+            "node-forge": "^0.7.1",
+            "split": "~0.3.3"
+         },
+         "dependencies": {
+            "bluebird": {
+               "version": "2.9.34",
+               "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz",
+               "integrity": "sha1-L3tOyAIWMoqf3evfacjUlC/v99g=",
+               "dev": true
+            }
+         }
+      },
+      "adbkit-logcat": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/adbkit-logcat/-/adbkit-logcat-1.1.0.tgz",
+         "integrity": "sha1-Adf5sM75CTowvLOwB+//MBUIli8=",
+         "dev": true
+      },
+      "adbkit-monkey": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/adbkit-monkey/-/adbkit-monkey-1.0.1.tgz",
+         "integrity": "sha1-8pG+cBou/FZ6Y/x6pq/N7TFDC+E=",
+         "dev": true,
+         "requires": {
+            "async": "~0.2.9"
+         },
+         "dependencies": {
+            "async": {
+               "version": "0.2.10",
+               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+               "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+               "dev": true
+            }
+         }
+      },
+      "addons-linter": {
+         "version": "1.14.0",
+         "resolved": "https://registry.npmjs.org/addons-linter/-/addons-linter-1.14.0.tgz",
+         "integrity": "sha512-Of7A53J2ltaIZzD8RPH1hVxOR+DmLDuHBtwfhXJw8JTXwzpDIvOKn/i6XDtPgfFlj5wIWxpUGV+tFb/kE/K9gg==",
+         "dev": true,
+         "requires": {
+            "ajv": "6.10.2",
+            "ajv-merge-patch": "4.1.0",
+            "chalk": "2.4.2",
+            "cheerio": "1.0.0-rc.3",
+            "columnify": "1.5.4",
+            "common-tags": "1.8.0",
+            "deepmerge": "4.0.0",
+            "dispensary": "0.40.0",
+            "es6-promisify": "6.0.2",
+            "eslint": "5.16.0",
+            "eslint-plugin-no-unsafe-innerhtml": "1.0.16",
+            "eslint-visitor-keys": "1.1.0",
+            "espree": "6.1.1",
+            "esprima": "4.0.1",
+            "first-chunk-stream": "3.0.0",
+            "fluent-syntax": "0.13.0",
+            "fsevents": "2.0.7",
+            "glob": "7.1.4",
+            "is-mergeable-object": "1.1.1",
+            "jed": "1.1.1",
+            "mdn-browser-compat-data": "0.0.94",
+            "os-locale": "4.0.0",
+            "pino": "5.13.3",
+            "po2json": "0.4.5",
+            "postcss": "7.0.18",
+            "probe-image-size": "5.0.0",
+            "regenerator-runtime": "0.13.3",
+            "relaxed-json": "1.0.3",
+            "semver": "6.3.0",
+            "source-map-support": "0.5.13",
+            "strip-bom-stream": "4.0.0",
+            "tosource": "1.0.0",
+            "upath": "1.2.0",
+            "whatwg-url": "7.0.0",
+            "yargs": "14.0.0",
+            "yauzl": "2.10.0"
+         },
+         "dependencies": {
+            "acorn": {
+               "version": "7.1.0",
+               "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+               "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+               "dev": true
+            },
+            "acorn-jsx": {
+               "version": "5.0.2",
+               "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
+               "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+               "dev": true
+            },
+            "camelcase": {
+               "version": "5.3.1",
+               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+               "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+               "dev": true
+            },
+            "cliui": {
+               "version": "5.0.0",
+               "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+               "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+               "dev": true,
+               "requires": {
+                  "string-width": "^3.1.0",
+                  "strip-ansi": "^5.2.0",
+                  "wrap-ansi": "^5.1.0"
+               }
+            },
+            "emoji-regex": {
+               "version": "7.0.3",
+               "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+               "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+               "dev": true
+            },
+            "espree": {
+               "version": "6.1.1",
+               "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
+               "integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+               "dev": true,
+               "requires": {
+                  "acorn": "^7.0.0",
+                  "acorn-jsx": "^5.0.2",
+                  "eslint-visitor-keys": "^1.1.0"
+               }
+            },
+            "fd-slicer": {
+               "version": "1.1.0",
+               "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+               "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+               "dev": true,
+               "requires": {
+                  "pend": "~1.2.0"
+               }
+            },
+            "fsevents": {
+               "version": "2.0.7",
+               "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
+               "integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
+               "dev": true,
+               "optional": true
+            },
+            "invert-kv": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-3.0.0.tgz",
+               "integrity": "sha512-JzF8q2BeZA1ZkE3XROwRpoMQ9ObMgTtp0JH8EXewlbkikuOj2GPLIpUipdO+VL8QsTr2teAJD02EFGGL5cO7uw==",
+               "dev": true
+            },
+            "is-fullwidth-code-point": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+               "dev": true
+            },
+            "lcid": {
+               "version": "3.1.1",
+               "resolved": "https://registry.npmjs.org/lcid/-/lcid-3.1.1.tgz",
+               "integrity": "sha512-M6T051+5QCGLBQb8id3hdvIW8+zeFV2FyBGFS9IEK5H9Wt4MueD4bW1eWikpHgZp+5xR3l5c8pZUkQsIA0BFZg==",
+               "dev": true,
+               "requires": {
+                  "invert-kv": "^3.0.0"
+               }
+            },
+            "mem": {
+               "version": "5.1.1",
+               "resolved": "https://registry.npmjs.org/mem/-/mem-5.1.1.tgz",
+               "integrity": "sha512-qvwipnozMohxLXG1pOqoLiZKNkC4r4qqRucSoDwXowsNGDSULiqFTRUF05vcZWnwJSG22qTsynQhxbaMtnX9gw==",
+               "dev": true,
+               "requires": {
+                  "map-age-cleaner": "^0.1.3",
+                  "mimic-fn": "^2.1.0",
+                  "p-is-promise": "^2.1.0"
+               }
+            },
+            "os-locale": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-4.0.0.tgz",
+               "integrity": "sha512-HsSR1+2l6as4Wp2SGZxqLnuFHxVvh1Ir9pvZxyujsC13egZVe7P0YeBLN0ijQzM/twrO5To3ia3jzBXAvpMTEA==",
+               "dev": true,
+               "requires": {
+                  "execa": "^1.0.0",
+                  "lcid": "^3.0.0",
+                  "mem": "^5.0.0"
+               }
+            },
+            "postcss": {
+               "version": "7.0.18",
+               "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
+               "integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
+               "dev": true,
+               "requires": {
+                  "chalk": "^2.4.2",
+                  "source-map": "^0.6.1",
+                  "supports-color": "^6.1.0"
+               }
+            },
+            "semver": {
+               "version": "6.3.0",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+               "dev": true
+            },
+            "source-map": {
+               "version": "0.6.1",
+               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+               "dev": true
+            },
+            "string-width": {
+               "version": "3.1.0",
+               "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+               "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+               "dev": true,
+               "requires": {
+                  "emoji-regex": "^7.0.1",
+                  "is-fullwidth-code-point": "^2.0.0",
+                  "strip-ansi": "^5.1.0"
+               }
+            },
+            "strip-ansi": {
+               "version": "5.2.0",
+               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+               "dev": true,
+               "requires": {
+                  "ansi-regex": "^4.1.0"
+               }
+            },
+            "supports-color": {
+               "version": "6.1.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+               "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+               "dev": true,
+               "requires": {
+                  "has-flag": "^3.0.0"
+               }
+            },
+            "upath": {
+               "version": "1.2.0",
+               "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+               "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+               "dev": true
+            },
+            "wrap-ansi": {
+               "version": "5.1.0",
+               "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+               "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^3.2.0",
+                  "string-width": "^3.0.0",
+                  "strip-ansi": "^5.0.0"
+               }
+            },
+            "yargs": {
+               "version": "14.0.0",
+               "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.0.0.tgz",
+               "integrity": "sha512-ssa5JuRjMeZEUjg7bEL99AwpitxU/zWGAGpdj0di41pOEmJti8NR6kyUIJBkR78DTYNPZOU08luUo0GTHuB+ow==",
+               "dev": true,
+               "requires": {
+                  "cliui": "^5.0.0",
+                  "decamelize": "^1.2.0",
+                  "find-up": "^3.0.0",
+                  "get-caller-file": "^2.0.1",
+                  "require-directory": "^2.1.1",
+                  "require-main-filename": "^2.0.0",
+                  "set-blocking": "^2.0.0",
+                  "string-width": "^3.0.0",
+                  "which-module": "^2.0.0",
+                  "y18n": "^4.0.0",
+                  "yargs-parser": "^13.1.1"
+               }
+            },
+            "yargs-parser": {
+               "version": "13.1.1",
+               "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+               "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+               "dev": true,
+               "requires": {
+                  "camelcase": "^5.0.0",
+                  "decamelize": "^1.2.0"
+               }
+            },
+            "yauzl": {
+               "version": "2.10.0",
+               "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+               "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+               "dev": true,
+               "requires": {
+                  "buffer-crc32": "~0.2.3",
+                  "fd-slicer": "~1.1.0"
+               }
+            }
+         }
+      },
+      "adm-zip": {
+         "version": "0.4.13",
+         "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
+         "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw==",
+         "dev": true
+      },
       "ajv": {
          "version": "6.10.2",
          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -1043,6 +1430,59 @@
          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
          "dev": true
+      },
+      "ajv-merge-patch": {
+         "version": "4.1.0",
+         "resolved": "https://registry.npmjs.org/ajv-merge-patch/-/ajv-merge-patch-4.1.0.tgz",
+         "integrity": "sha512-0mAYXMSauA8RZ7r+B4+EAOYcZEcO9OK5EiQCR7W7Cv4E44pJj56ZnkKLJ9/PAcOc0dT+LlV9fdDcq2TxVJfOYw==",
+         "dev": true,
+         "requires": {
+            "fast-json-patch": "^2.0.6",
+            "json-merge-patch": "^0.2.3"
+         }
+      },
+      "ansi-align": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
+         "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+         "dev": true,
+         "requires": {
+            "string-width": "^3.0.0"
+         },
+         "dependencies": {
+            "emoji-regex": {
+               "version": "7.0.3",
+               "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+               "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+               "dev": true
+            },
+            "is-fullwidth-code-point": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+               "dev": true
+            },
+            "string-width": {
+               "version": "3.1.0",
+               "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+               "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+               "dev": true,
+               "requires": {
+                  "emoji-regex": "^7.0.1",
+                  "is-fullwidth-code-point": "^2.0.0",
+                  "strip-ansi": "^5.1.0"
+               }
+            },
+            "strip-ansi": {
+               "version": "5.2.0",
+               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+               "dev": true,
+               "requires": {
+                  "ansi-regex": "^4.1.0"
+               }
+            }
+         }
       },
       "ansi-colors": {
          "version": "3.2.3",
@@ -1073,6 +1513,12 @@
          "requires": {
             "color-convert": "^1.9.0"
          }
+      },
+      "any-promise": {
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+         "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+         "dev": true
       },
       "anymatch": {
          "version": "2.0.0",
@@ -1114,6 +1560,77 @@
             }
          }
       },
+      "aproba": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+         "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+         "dev": true,
+         "optional": true
+      },
+      "archiver": {
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
+         "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
+         "dev": true,
+         "requires": {
+            "archiver-utils": "^1.3.0",
+            "async": "^2.0.0",
+            "buffer-crc32": "^0.2.1",
+            "glob": "^7.0.0",
+            "lodash": "^4.8.0",
+            "readable-stream": "^2.0.0",
+            "tar-stream": "^1.5.0",
+            "walkdir": "^0.0.11",
+            "zip-stream": "^1.1.0"
+         },
+         "dependencies": {
+            "async": {
+               "version": "2.6.3",
+               "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+               "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+               "dev": true,
+               "requires": {
+                  "lodash": "^4.17.14"
+               }
+            }
+         }
+      },
+      "archiver-utils": {
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+         "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+         "dev": true,
+         "requires": {
+            "glob": "^7.0.0",
+            "graceful-fs": "^4.1.0",
+            "lazystream": "^1.0.0",
+            "lodash": "^4.8.0",
+            "normalize-path": "^2.0.0",
+            "readable-stream": "^2.0.0"
+         },
+         "dependencies": {
+            "normalize-path": {
+               "version": "2.1.1",
+               "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+               "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+               "dev": true,
+               "requires": {
+                  "remove-trailing-separator": "^1.0.1"
+               }
+            }
+         }
+      },
+      "are-we-there-yet": {
+         "version": "1.1.5",
+         "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+         "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+         "dev": true,
+         "optional": true,
+         "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+         }
+      },
       "argparse": {
          "version": "1.0.10",
          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1141,16 +1658,40 @@
          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
          "dev": true
       },
+      "array-differ": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+         "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+         "dev": true
+      },
       "array-equal": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
          "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
          "dev": true
       },
+      "array-filter": {
+         "version": "0.0.1",
+         "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+         "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+         "dev": true
+      },
       "array-find-index": {
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
          "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+         "dev": true
+      },
+      "array-map": {
+         "version": "0.0.0",
+         "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+         "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+         "dev": true
+      },
+      "array-reduce": {
+         "version": "0.0.0",
+         "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+         "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
          "dev": true
       },
       "array-union": {
@@ -1397,6 +1938,43 @@
             "object.assign": "^4.1.0"
          }
       },
+      "babel-polyfill": {
+         "version": "6.16.0",
+         "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.16.0.tgz",
+         "integrity": "sha1-LUUCHfh+JqN0ttTRqcZZZNF/JCI=",
+         "dev": true,
+         "requires": {
+            "babel-runtime": "^6.9.1",
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.9.5"
+         },
+         "dependencies": {
+            "regenerator-runtime": {
+               "version": "0.9.6",
+               "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
+               "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck=",
+               "dev": true
+            }
+         }
+      },
+      "babel-runtime": {
+         "version": "6.26.0",
+         "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+         "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+         "dev": true,
+         "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
+         },
+         "dependencies": {
+            "regenerator-runtime": {
+               "version": "0.11.1",
+               "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+               "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+               "dev": true
+            }
+         }
+      },
       "babelify": {
          "version": "10.0.0",
          "resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
@@ -1497,6 +2075,26 @@
          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
          "dev": true
       },
+      "bl": {
+         "version": "1.2.2",
+         "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+         "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+         "dev": true,
+         "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+         }
+      },
+      "block-stream": {
+         "version": "0.0.9",
+         "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+         "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+         "dev": true,
+         "optional": true,
+         "requires": {
+            "inherits": "~2.0.0"
+         }
+      },
       "bluebird": {
          "version": "3.5.5",
          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
@@ -1508,6 +2106,74 @@
          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
          "dev": true
+      },
+      "boolbase": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+         "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+         "dev": true
+      },
+      "boxen": {
+         "version": "3.2.0",
+         "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
+         "integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
+         "dev": true,
+         "requires": {
+            "ansi-align": "^3.0.0",
+            "camelcase": "^5.3.1",
+            "chalk": "^2.4.2",
+            "cli-boxes": "^2.2.0",
+            "string-width": "^3.0.0",
+            "term-size": "^1.2.0",
+            "type-fest": "^0.3.0",
+            "widest-line": "^2.0.0"
+         },
+         "dependencies": {
+            "camelcase": {
+               "version": "5.3.1",
+               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+               "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+               "dev": true
+            },
+            "emoji-regex": {
+               "version": "7.0.3",
+               "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+               "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+               "dev": true
+            },
+            "is-fullwidth-code-point": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+               "dev": true
+            },
+            "string-width": {
+               "version": "3.1.0",
+               "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+               "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+               "dev": true,
+               "requires": {
+                  "emoji-regex": "^7.0.1",
+                  "is-fullwidth-code-point": "^2.0.0",
+                  "strip-ansi": "^5.1.0"
+               }
+            },
+            "strip-ansi": {
+               "version": "5.2.0",
+               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+               "dev": true,
+               "requires": {
+                  "ansi-regex": "^4.1.0"
+               }
+            },
+            "type-fest": {
+               "version": "0.3.1",
+               "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+               "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+               "dev": true
+            }
+         }
       },
       "brace-expansion": {
          "version": "1.1.11",
@@ -1794,6 +2460,40 @@
             "ieee754": "^1.1.4"
          }
       },
+      "buffer-alloc": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+         "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+         "dev": true,
+         "requires": {
+            "buffer-alloc-unsafe": "^1.1.0",
+            "buffer-fill": "^1.0.0"
+         }
+      },
+      "buffer-alloc-unsafe": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+         "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+         "dev": true
+      },
+      "buffer-crc32": {
+         "version": "0.2.13",
+         "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+         "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+         "dev": true
+      },
+      "buffer-equal-constant-time": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+         "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+         "dev": true
+      },
+      "buffer-fill": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+         "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+         "dev": true
+      },
       "buffer-from": {
          "version": "1.1.1",
          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -1812,6 +2512,18 @@
          "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
          "dev": true
       },
+      "bunyan": {
+         "version": "1.8.12",
+         "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
+         "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+         "dev": true,
+         "requires": {
+            "dtrace-provider": "~0.8",
+            "moment": "^2.10.6",
+            "mv": "~2",
+            "safe-json-stringify": "~1"
+         }
+      },
       "cache-base": {
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -1827,6 +2539,38 @@
             "to-object-path": "^0.3.0",
             "union-value": "^1.0.0",
             "unset-value": "^1.0.0"
+         }
+      },
+      "cacheable-request": {
+         "version": "6.1.0",
+         "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+         "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+         "dev": true,
+         "requires": {
+            "clone-response": "^1.0.2",
+            "get-stream": "^5.1.0",
+            "http-cache-semantics": "^4.0.0",
+            "keyv": "^3.0.0",
+            "lowercase-keys": "^2.0.0",
+            "normalize-url": "^4.1.0",
+            "responselike": "^1.0.2"
+         },
+         "dependencies": {
+            "get-stream": {
+               "version": "5.1.0",
+               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+               "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+               "dev": true,
+               "requires": {
+                  "pump": "^3.0.0"
+               }
+            },
+            "lowercase-keys": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+               "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+               "dev": true
+            }
          }
       },
       "cached-path-relative": {
@@ -1976,6 +2720,41 @@
          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
          "dev": true
       },
+      "cheerio": {
+         "version": "1.0.0-rc.3",
+         "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+         "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+         "dev": true,
+         "requires": {
+            "css-select": "~1.2.0",
+            "dom-serializer": "~0.1.1",
+            "entities": "~1.1.1",
+            "htmlparser2": "^3.9.1",
+            "lodash": "^4.15.0",
+            "parse5": "^3.0.1"
+         },
+         "dependencies": {
+            "dom-serializer": {
+               "version": "0.1.1",
+               "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+               "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+               "dev": true,
+               "requires": {
+                  "domelementtype": "^1.3.0",
+                  "entities": "^1.1.1"
+               }
+            },
+            "parse5": {
+               "version": "3.0.3",
+               "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+               "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+               "dev": true,
+               "requires": {
+                  "@types/node": "*"
+               }
+            }
+         }
+      },
       "chokidar": {
          "version": "2.1.6",
          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
@@ -1995,6 +2774,32 @@
             "readdirp": "^2.2.1",
             "upath": "^1.1.1"
          }
+      },
+      "chownr": {
+         "version": "1.1.3",
+         "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+         "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+         "dev": true,
+         "optional": true
+      },
+      "chrome-launcher": {
+         "version": "0.11.2",
+         "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.11.2.tgz",
+         "integrity": "sha512-jx0kJDCXdB2ARcDMwNCtrf04oY1Up4rOmVu+fqJ5MTPOOIG8EhRcEU9NZfXZc6dMw9FU8o1r21PNp8V2M0zQ+g==",
+         "dev": true,
+         "requires": {
+            "@types/node": "*",
+            "is-wsl": "^2.1.0",
+            "lighthouse-logger": "^1.0.0",
+            "mkdirp": "0.5.1",
+            "rimraf": "^2.6.1"
+         }
+      },
+      "ci-info": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+         "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+         "dev": true
       },
       "cipher-base": {
          "version": "1.0.4",
@@ -2034,6 +2839,12 @@
                }
             }
          }
+      },
+      "cli-boxes": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
+         "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
+         "dev": true
       },
       "cli-cursor": {
          "version": "3.1.0",
@@ -2094,6 +2905,15 @@
             "is-regexp": "^2.0.0"
          }
       },
+      "clone-response": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+         "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+         "dev": true,
+         "requires": {
+            "mimic-response": "^1.0.0"
+         }
+      },
       "co": {
          "version": "4.6.0",
          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2149,6 +2969,33 @@
          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
          "dev": true
       },
+      "columnify": {
+         "version": "1.5.4",
+         "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+         "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+         "dev": true,
+         "requires": {
+            "strip-ansi": "^3.0.0",
+            "wcwidth": "^1.0.0"
+         },
+         "dependencies": {
+            "ansi-regex": {
+               "version": "2.1.1",
+               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+               "dev": true
+            },
+            "strip-ansi": {
+               "version": "3.0.1",
+               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+               "dev": true,
+               "requires": {
+                  "ansi-regex": "^2.0.0"
+               }
+            }
+         }
+      },
       "combine-source-map": {
          "version": "0.8.0",
          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
@@ -2184,6 +3031,12 @@
          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
          "dev": true
       },
+      "common-tags": {
+         "version": "1.8.0",
+         "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+         "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+         "dev": true
+      },
       "commondir": {
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -2195,6 +3048,29 @@
          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
          "dev": true
+      },
+      "compress-commons": {
+         "version": "1.2.2",
+         "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+         "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+         "dev": true,
+         "requires": {
+            "buffer-crc32": "^0.2.1",
+            "crc32-stream": "^2.0.0",
+            "normalize-path": "^2.0.0",
+            "readable-stream": "^2.0.0"
+         },
+         "dependencies": {
+            "normalize-path": {
+               "version": "2.1.1",
+               "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+               "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+               "dev": true,
+               "requires": {
+                  "remove-trailing-separator": "^1.0.1"
+               }
+            }
+         }
       },
       "concat-map": {
          "version": "0.0.1",
@@ -2214,6 +3090,37 @@
             "typedarray": "^0.0.6"
          }
       },
+      "configstore": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
+         "integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
+         "dev": true,
+         "requires": {
+            "dot-prop": "^4.1.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^1.0.0",
+            "unique-string": "^1.0.0",
+            "write-file-atomic": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+         },
+         "dependencies": {
+            "make-dir": {
+               "version": "1.3.0",
+               "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+               "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+               "dev": true,
+               "requires": {
+                  "pify": "^3.0.0"
+               }
+            },
+            "pify": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+               "dev": true
+            }
+         }
+      },
       "console-browserify": {
          "version": "1.1.0",
          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
@@ -2222,6 +3129,13 @@
          "requires": {
             "date-now": "^0.1.4"
          }
+      },
+      "console-control-strings": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+         "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+         "dev": true,
+         "optional": true
       },
       "constants-browserify": {
          "version": "1.0.0",
@@ -2322,6 +3236,25 @@
             }
          }
       },
+      "crc": {
+         "version": "3.8.0",
+         "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+         "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+         "dev": true,
+         "requires": {
+            "buffer": "^5.1.0"
+         }
+      },
+      "crc32-stream": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+         "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+         "dev": true,
+         "requires": {
+            "crc": "^3.4.4",
+            "readable-stream": "^2.0.0"
+         }
+      },
       "create-ecdh": {
          "version": "4.0.3",
          "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
@@ -2391,6 +3324,12 @@
             "randomfill": "^1.0.3"
          }
       },
+      "crypto-random-string": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+         "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+         "dev": true
+      },
       "cson-parser": {
          "version": "1.3.5",
          "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
@@ -2407,6 +3346,36 @@
                "dev": true
             }
          }
+      },
+      "css-select": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+         "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+         "dev": true,
+         "requires": {
+            "boolbase": "~1.0.0",
+            "css-what": "2.1",
+            "domutils": "1.5.1",
+            "nth-check": "~1.0.1"
+         },
+         "dependencies": {
+            "domutils": {
+               "version": "1.5.1",
+               "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+               "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+               "dev": true,
+               "requires": {
+                  "dom-serializer": "0",
+                  "domelementtype": "1"
+               }
+            }
+         }
+      },
+      "css-what": {
+         "version": "2.1.3",
+         "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+         "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+         "dev": true
       },
       "cssom": {
          "version": "0.3.8",
@@ -2430,6 +3399,16 @@
          "dev": true,
          "requires": {
             "array-find-index": "^1.0.1"
+         }
+      },
+      "d": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+         "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+         "dev": true,
+         "requires": {
+            "es5-ext": "^0.10.50",
+            "type": "^1.0.1"
          }
       },
       "dash-ast": {
@@ -2474,6 +3453,12 @@
             "meow": "^3.3.0"
          }
       },
+      "debounce": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
+         "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==",
+         "dev": true
+      },
       "debug": {
          "version": "2.6.9",
          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2505,6 +3490,15 @@
          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
          "dev": true
       },
+      "decompress-response": {
+         "version": "3.3.0",
+         "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+         "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+         "dev": true,
+         "requires": {
+            "mimic-response": "^1.0.0"
+         }
+      },
       "deep-eql": {
          "version": "0.1.3",
          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
@@ -2522,10 +3516,65 @@
             }
          }
       },
+      "deep-equal": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
+         "integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+         "dev": true,
+         "requires": {
+            "is-arguments": "^1.0.4",
+            "is-date-object": "^1.0.1",
+            "is-regex": "^1.0.4",
+            "object-is": "^1.0.1",
+            "object-keys": "^1.1.1",
+            "regexp.prototype.flags": "^1.2.0"
+         }
+      },
+      "deep-extend": {
+         "version": "0.6.0",
+         "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+         "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+         "dev": true
+      },
       "deep-is": {
          "version": "0.1.3",
          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+         "dev": true
+      },
+      "deepcopy": {
+         "version": "0.6.3",
+         "resolved": "https://registry.npmjs.org/deepcopy/-/deepcopy-0.6.3.tgz",
+         "integrity": "sha1-Y0eA8vhlardxr4+oQx7RzO5Vx7A=",
+         "dev": true
+      },
+      "deepmerge": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.0.0.tgz",
+         "integrity": "sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww==",
+         "dev": true
+      },
+      "defaults": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+         "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+         "dev": true,
+         "requires": {
+            "clone": "^1.0.2"
+         },
+         "dependencies": {
+            "clone": {
+               "version": "1.0.4",
+               "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+               "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+               "dev": true
+            }
+         }
+      },
+      "defer-to-connect": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
+         "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==",
          "dev": true
       },
       "define-properties": {
@@ -2590,6 +3639,13 @@
          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
          "dev": true
       },
+      "delegates": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+         "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+         "dev": true,
+         "optional": true
+      },
       "deps-sort": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
@@ -2611,6 +3667,13 @@
             "inherits": "^2.0.1",
             "minimalistic-assert": "^1.0.0"
          }
+      },
+      "detect-libc": {
+         "version": "0.2.0",
+         "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-0.2.0.tgz",
+         "integrity": "sha1-R/31ZzSKF+wl/L8LnkRjSKdvn7U=",
+         "dev": true,
+         "optional": true
       },
       "detective": {
          "version": "5.2.0",
@@ -2671,6 +3734,118 @@
                "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
                "dev": true
+            }
+         }
+      },
+      "dispensary": {
+         "version": "0.40.0",
+         "resolved": "https://registry.npmjs.org/dispensary/-/dispensary-0.40.0.tgz",
+         "integrity": "sha512-ttKDQvGBf+ygQ4rXuLBLErp3kMJIS+Gfmy+nJ6N/EfV8/RQdjd9SORpc729YK5SYAI+IuBo88S2xGUjKjU2jYw==",
+         "dev": true,
+         "requires": {
+            "async": "~3.1.0",
+            "natural-compare-lite": "~1.4.0",
+            "pino": "~5.13.0",
+            "request": "~2.88.0",
+            "sha.js": "~2.4.4",
+            "source-map-support": "~0.5.4",
+            "yargs": "~14.0.0"
+         },
+         "dependencies": {
+            "async": {
+               "version": "3.1.0",
+               "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
+               "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ==",
+               "dev": true
+            },
+            "camelcase": {
+               "version": "5.3.1",
+               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+               "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+               "dev": true
+            },
+            "cliui": {
+               "version": "5.0.0",
+               "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+               "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+               "dev": true,
+               "requires": {
+                  "string-width": "^3.1.0",
+                  "strip-ansi": "^5.2.0",
+                  "wrap-ansi": "^5.1.0"
+               }
+            },
+            "emoji-regex": {
+               "version": "7.0.3",
+               "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+               "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+               "dev": true
+            },
+            "is-fullwidth-code-point": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+               "dev": true
+            },
+            "string-width": {
+               "version": "3.1.0",
+               "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+               "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+               "dev": true,
+               "requires": {
+                  "emoji-regex": "^7.0.1",
+                  "is-fullwidth-code-point": "^2.0.0",
+                  "strip-ansi": "^5.1.0"
+               }
+            },
+            "strip-ansi": {
+               "version": "5.2.0",
+               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+               "dev": true,
+               "requires": {
+                  "ansi-regex": "^4.1.0"
+               }
+            },
+            "wrap-ansi": {
+               "version": "5.1.0",
+               "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+               "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^3.2.0",
+                  "string-width": "^3.0.0",
+                  "strip-ansi": "^5.0.0"
+               }
+            },
+            "yargs": {
+               "version": "14.0.0",
+               "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.0.0.tgz",
+               "integrity": "sha512-ssa5JuRjMeZEUjg7bEL99AwpitxU/zWGAGpdj0di41pOEmJti8NR6kyUIJBkR78DTYNPZOU08luUo0GTHuB+ow==",
+               "dev": true,
+               "requires": {
+                  "cliui": "^5.0.0",
+                  "decamelize": "^1.2.0",
+                  "find-up": "^3.0.0",
+                  "get-caller-file": "^2.0.1",
+                  "require-directory": "^2.1.1",
+                  "require-main-filename": "^2.0.0",
+                  "set-blocking": "^2.0.0",
+                  "string-width": "^3.0.0",
+                  "which-module": "^2.0.0",
+                  "y18n": "^4.0.0",
+                  "yargs-parser": "^13.1.1"
+               }
+            },
+            "yargs-parser": {
+               "version": "13.1.1",
+               "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+               "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+               "dev": true,
+               "requires": {
+                  "camelcase": "^5.0.0",
+                  "decamelize": "^1.2.0"
+               }
             }
          }
       },
@@ -2762,6 +3937,16 @@
             "is-obj": "^1.0.0"
          }
       },
+      "dtrace-provider": {
+         "version": "0.8.8",
+         "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
+         "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
+         "dev": true,
+         "optional": true,
+         "requires": {
+            "nan": "^2.14.0"
+         }
+      },
       "duplexer2": {
          "version": "0.1.4",
          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -2771,6 +3956,12 @@
             "readable-stream": "^2.0.2"
          }
       },
+      "duplexer3": {
+         "version": "0.1.4",
+         "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+         "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+         "dev": true
+      },
       "ecc-jsbn": {
          "version": "0.1.2",
          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -2779,6 +3970,15 @@
          "requires": {
             "jsbn": "~0.1.0",
             "safer-buffer": "^2.1.0"
+         }
+      },
+      "ecdsa-sig-formatter": {
+         "version": "1.0.11",
+         "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+         "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+         "dev": true,
+         "requires": {
+            "safe-buffer": "^5.0.1"
          }
       },
       "electron-to-chromium": {
@@ -2813,6 +4013,15 @@
          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
          "dev": true
+      },
+      "encoding": {
+         "version": "0.1.12",
+         "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+         "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+         "dev": true,
+         "requires": {
+            "iconv-lite": "~0.4.13"
+         }
       },
       "end-of-stream": {
          "version": "1.4.1",
@@ -2873,11 +4082,106 @@
             "is-symbol": "^1.0.2"
          }
       },
+      "es5-ext": {
+         "version": "0.10.51",
+         "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz",
+         "integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
+         "dev": true,
+         "requires": {
+            "es6-iterator": "~2.0.3",
+            "es6-symbol": "~3.1.1",
+            "next-tick": "^1.0.0"
+         }
+      },
+      "es6-error": {
+         "version": "4.1.1",
+         "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+         "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+         "dev": true
+      },
+      "es6-iterator": {
+         "version": "2.0.3",
+         "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+         "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+         "dev": true,
+         "requires": {
+            "d": "1",
+            "es5-ext": "^0.10.35",
+            "es6-symbol": "^3.1.1"
+         }
+      },
+      "es6-map": {
+         "version": "0.1.5",
+         "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+         "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+         "dev": true,
+         "requires": {
+            "d": "1",
+            "es5-ext": "~0.10.14",
+            "es6-iterator": "~2.0.1",
+            "es6-set": "~0.1.5",
+            "es6-symbol": "~3.1.1",
+            "event-emitter": "~0.3.5"
+         }
+      },
       "es6-promise": {
          "version": "4.2.8",
          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
          "dev": true
+      },
+      "es6-promisify": {
+         "version": "6.0.2",
+         "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.2.tgz",
+         "integrity": "sha512-eO6vFm0JvqGzjWIQA6QVKjxpmELfhWbDUWHm1rPfIbn55mhKPiAa5xpLmQWJrNa629ZIeQ8ZvMAi13kvrjK6Mg==",
+         "dev": true
+      },
+      "es6-set": {
+         "version": "0.1.5",
+         "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+         "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+         "dev": true,
+         "requires": {
+            "d": "1",
+            "es5-ext": "~0.10.14",
+            "es6-iterator": "~2.0.1",
+            "es6-symbol": "3.1.1",
+            "event-emitter": "~0.3.5"
+         },
+         "dependencies": {
+            "es6-symbol": {
+               "version": "3.1.1",
+               "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+               "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+               "dev": true,
+               "requires": {
+                  "d": "1",
+                  "es5-ext": "~0.10.14"
+               }
+            }
+         }
+      },
+      "es6-symbol": {
+         "version": "3.1.2",
+         "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.2.tgz",
+         "integrity": "sha512-/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==",
+         "dev": true,
+         "requires": {
+            "d": "^1.0.1",
+            "es5-ext": "^0.10.51"
+         }
+      },
+      "es6-weak-map": {
+         "version": "2.0.3",
+         "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+         "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+         "dev": true,
+         "requires": {
+            "d": "1",
+            "es5-ext": "^0.10.46",
+            "es6-iterator": "^2.0.3",
+            "es6-symbol": "^3.1.1"
+         }
       },
       "escape-string-regexp": {
          "version": "1.0.5",
@@ -2911,6 +4215,18 @@
                "dev": true,
                "optional": true
             }
+         }
+      },
+      "escope": {
+         "version": "3.6.0",
+         "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+         "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+         "dev": true,
+         "requires": {
+            "es6-map": "^0.1.3",
+            "es6-weak-map": "^2.0.1",
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
          }
       },
       "eslint": {
@@ -2990,6 +4306,384 @@
             "object-assign": "^3.0.0"
          }
       },
+      "eslint-plugin-no-unsafe-innerhtml": {
+         "version": "1.0.16",
+         "resolved": "https://registry.npmjs.org/eslint-plugin-no-unsafe-innerhtml/-/eslint-plugin-no-unsafe-innerhtml-1.0.16.tgz",
+         "integrity": "sha1-fQKHjI6b95FriINtWsEitC8VGTI=",
+         "dev": true,
+         "requires": {
+            "eslint": "^3.7.1"
+         },
+         "dependencies": {
+            "acorn": {
+               "version": "5.7.3",
+               "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+               "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+               "dev": true
+            },
+            "acorn-jsx": {
+               "version": "3.0.1",
+               "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+               "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+               "dev": true,
+               "requires": {
+                  "acorn": "^3.0.4"
+               },
+               "dependencies": {
+                  "acorn": {
+                     "version": "3.3.0",
+                     "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                     "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+                     "dev": true
+                  }
+               }
+            },
+            "ajv": {
+               "version": "4.11.8",
+               "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+               "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+               "dev": true,
+               "requires": {
+                  "co": "^4.6.0",
+                  "json-stable-stringify": "^1.0.1"
+               }
+            },
+            "ajv-keywords": {
+               "version": "1.5.1",
+               "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+               "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+               "dev": true
+            },
+            "ansi-escapes": {
+               "version": "1.4.0",
+               "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+               "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+               "dev": true
+            },
+            "ansi-regex": {
+               "version": "2.1.1",
+               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+               "dev": true
+            },
+            "ansi-styles": {
+               "version": "2.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+               "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+               "dev": true
+            },
+            "chalk": {
+               "version": "1.1.3",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^2.2.1",
+                  "escape-string-regexp": "^1.0.2",
+                  "has-ansi": "^2.0.0",
+                  "strip-ansi": "^3.0.0",
+                  "supports-color": "^2.0.0"
+               }
+            },
+            "cli-cursor": {
+               "version": "1.0.2",
+               "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+               "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+               "dev": true,
+               "requires": {
+                  "restore-cursor": "^1.0.1"
+               }
+            },
+            "doctrine": {
+               "version": "2.1.0",
+               "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+               "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+               "dev": true,
+               "requires": {
+                  "esutils": "^2.0.2"
+               }
+            },
+            "eslint": {
+               "version": "3.19.0",
+               "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+               "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+               "dev": true,
+               "requires": {
+                  "babel-code-frame": "^6.16.0",
+                  "chalk": "^1.1.3",
+                  "concat-stream": "^1.5.2",
+                  "debug": "^2.1.1",
+                  "doctrine": "^2.0.0",
+                  "escope": "^3.6.0",
+                  "espree": "^3.4.0",
+                  "esquery": "^1.0.0",
+                  "estraverse": "^4.2.0",
+                  "esutils": "^2.0.2",
+                  "file-entry-cache": "^2.0.0",
+                  "glob": "^7.0.3",
+                  "globals": "^9.14.0",
+                  "ignore": "^3.2.0",
+                  "imurmurhash": "^0.1.4",
+                  "inquirer": "^0.12.0",
+                  "is-my-json-valid": "^2.10.0",
+                  "is-resolvable": "^1.0.0",
+                  "js-yaml": "^3.5.1",
+                  "json-stable-stringify": "^1.0.0",
+                  "levn": "^0.3.0",
+                  "lodash": "^4.0.0",
+                  "mkdirp": "^0.5.0",
+                  "natural-compare": "^1.4.0",
+                  "optionator": "^0.8.2",
+                  "path-is-inside": "^1.0.1",
+                  "pluralize": "^1.2.1",
+                  "progress": "^1.1.8",
+                  "require-uncached": "^1.0.2",
+                  "shelljs": "^0.7.5",
+                  "strip-bom": "^3.0.0",
+                  "strip-json-comments": "~2.0.1",
+                  "table": "^3.7.8",
+                  "text-table": "~0.2.0",
+                  "user-home": "^2.0.0"
+               }
+            },
+            "espree": {
+               "version": "3.5.4",
+               "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+               "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+               "dev": true,
+               "requires": {
+                  "acorn": "^5.5.0",
+                  "acorn-jsx": "^3.0.0"
+               }
+            },
+            "figures": {
+               "version": "1.7.0",
+               "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+               "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+               "dev": true,
+               "requires": {
+                  "escape-string-regexp": "^1.0.5",
+                  "object-assign": "^4.1.0"
+               }
+            },
+            "file-entry-cache": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+               "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+               "dev": true,
+               "requires": {
+                  "flat-cache": "^1.2.1",
+                  "object-assign": "^4.0.1"
+               }
+            },
+            "flat-cache": {
+               "version": "1.3.4",
+               "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+               "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+               "dev": true,
+               "requires": {
+                  "circular-json": "^0.3.1",
+                  "graceful-fs": "^4.1.2",
+                  "rimraf": "~2.6.2",
+                  "write": "^0.2.1"
+               }
+            },
+            "globals": {
+               "version": "9.18.0",
+               "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+               "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+               "dev": true
+            },
+            "ignore": {
+               "version": "3.3.10",
+               "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+               "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+               "dev": true
+            },
+            "inquirer": {
+               "version": "0.12.0",
+               "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+               "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+               "dev": true,
+               "requires": {
+                  "ansi-escapes": "^1.1.0",
+                  "ansi-regex": "^2.0.0",
+                  "chalk": "^1.0.0",
+                  "cli-cursor": "^1.0.1",
+                  "cli-width": "^2.0.0",
+                  "figures": "^1.3.5",
+                  "lodash": "^4.3.0",
+                  "readline2": "^1.0.1",
+                  "run-async": "^0.1.0",
+                  "rx-lite": "^3.1.2",
+                  "string-width": "^1.0.1",
+                  "strip-ansi": "^3.0.0",
+                  "through": "^2.3.6"
+               }
+            },
+            "is-fullwidth-code-point": {
+               "version": "1.0.0",
+               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+               "dev": true,
+               "requires": {
+                  "number-is-nan": "^1.0.0"
+               }
+            },
+            "json-stable-stringify": {
+               "version": "1.0.1",
+               "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+               "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+               "dev": true,
+               "requires": {
+                  "jsonify": "~0.0.0"
+               }
+            },
+            "object-assign": {
+               "version": "4.1.1",
+               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+               "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+               "dev": true
+            },
+            "onetime": {
+               "version": "1.1.0",
+               "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+               "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+               "dev": true
+            },
+            "pluralize": {
+               "version": "1.2.1",
+               "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+               "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+               "dev": true
+            },
+            "progress": {
+               "version": "1.1.8",
+               "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+               "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+               "dev": true
+            },
+            "restore-cursor": {
+               "version": "1.0.1",
+               "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+               "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+               "dev": true,
+               "requires": {
+                  "exit-hook": "^1.0.0",
+                  "onetime": "^1.0.0"
+               }
+            },
+            "run-async": {
+               "version": "0.1.0",
+               "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+               "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+               "dev": true,
+               "requires": {
+                  "once": "^1.3.0"
+               }
+            },
+            "rx-lite": {
+               "version": "3.1.2",
+               "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+               "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+               "dev": true
+            },
+            "slice-ansi": {
+               "version": "0.0.4",
+               "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+               "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+               "dev": true
+            },
+            "string-width": {
+               "version": "1.0.2",
+               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+               "dev": true,
+               "requires": {
+                  "code-point-at": "^1.0.0",
+                  "is-fullwidth-code-point": "^1.0.0",
+                  "strip-ansi": "^3.0.0"
+               }
+            },
+            "strip-ansi": {
+               "version": "3.0.1",
+               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+               "dev": true,
+               "requires": {
+                  "ansi-regex": "^2.0.0"
+               }
+            },
+            "strip-bom": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+               "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+               "dev": true
+            },
+            "supports-color": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+               "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+               "dev": true
+            },
+            "table": {
+               "version": "3.8.3",
+               "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+               "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+               "dev": true,
+               "requires": {
+                  "ajv": "^4.7.0",
+                  "ajv-keywords": "^1.0.0",
+                  "chalk": "^1.1.1",
+                  "lodash": "^4.0.0",
+                  "slice-ansi": "0.0.4",
+                  "string-width": "^2.0.0"
+               },
+               "dependencies": {
+                  "ansi-regex": {
+                     "version": "3.0.0",
+                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                     "dev": true
+                  },
+                  "is-fullwidth-code-point": {
+                     "version": "2.0.0",
+                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                     "dev": true
+                  },
+                  "string-width": {
+                     "version": "2.1.1",
+                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                     "dev": true,
+                     "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                     }
+                  },
+                  "strip-ansi": {
+                     "version": "4.0.0",
+                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                     "dev": true,
+                     "requires": {
+                        "ansi-regex": "^3.0.0"
+                     }
+                  }
+               }
+            },
+            "write": {
+               "version": "0.2.1",
+               "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+               "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+               "dev": true,
+               "requires": {
+                  "mkdirp": "^0.5.1"
+               }
+            }
+         }
+      },
       "eslint-scope": {
          "version": "4.0.3",
          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -3062,6 +4756,22 @@
          "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
          "dev": true
       },
+      "event-emitter": {
+         "version": "0.3.5",
+         "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+         "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+         "dev": true,
+         "requires": {
+            "d": "1",
+            "es5-ext": "~0.10.14"
+         }
+      },
+      "event-to-promise": {
+         "version": "0.8.0",
+         "resolved": "https://registry.npmjs.org/event-to-promise/-/event-to-promise-0.8.0.tgz",
+         "integrity": "sha1-S4TxF3K28l93Uvx02XFTGsb1tiY=",
+         "dev": true
+      },
       "eventemitter2": {
          "version": "0.4.14",
          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
@@ -3114,6 +4824,12 @@
          "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
          "dev": true
       },
+      "exit-hook": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+         "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+         "dev": true
+      },
       "expand-brackets": {
          "version": "2.1.4",
          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -3148,6 +4864,13 @@
                }
             }
          }
+      },
+      "expand-template": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
+         "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==",
+         "dev": true,
+         "optional": true
       },
       "extend": {
          "version": "3.0.2",
@@ -3290,6 +5013,15 @@
             "micromatch": "^3.1.10"
          }
       },
+      "fast-json-patch": {
+         "version": "2.2.1",
+         "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
+         "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
+         "dev": true,
+         "requires": {
+            "fast-deep-equal": "^2.0.1"
+         }
+      },
       "fast-json-stable-stringify": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -3300,6 +5032,18 @@
          "version": "2.0.6",
          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
          "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+         "dev": true
+      },
+      "fast-redact": {
+         "version": "1.5.0",
+         "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-1.5.0.tgz",
+         "integrity": "sha512-Afo61CgUjkzdvOKDHn08qnZ0kwck38AOGcMlvSGzvJbIab6soAP5rdoQayecGCDsD69AiF9vJBXyq31eoEO2tQ==",
+         "dev": true
+      },
+      "fast-safe-stringify": {
+         "version": "2.0.7",
+         "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+         "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
          "dev": true
       },
       "fd-slicer": {
@@ -3402,6 +5146,84 @@
             }
          }
       },
+      "firefox-profile": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-1.2.0.tgz",
+         "integrity": "sha512-TTEFfPOkyaz4EWx/5ZDQC1mJAe3a+JgVcchpIfD4Tvx1UspwlTJRJxOYA35x/z2iJcxaF6aW2rdh6oj6qwgd2g==",
+         "dev": true,
+         "requires": {
+            "adm-zip": "~0.4.x",
+            "archiver": "~2.1.0",
+            "async": "~2.5.0",
+            "fs-extra": "~4.0.2",
+            "ini": "~1.3.3",
+            "jetpack-id": "1.0.0",
+            "lazystream": "~1.0.0",
+            "lodash": "~4.17.2",
+            "minimist": "^1.1.1",
+            "uuid": "^3.0.0",
+            "xml2js": "~0.4.4"
+         },
+         "dependencies": {
+            "archiver": {
+               "version": "2.1.1",
+               "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
+               "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
+               "dev": true,
+               "requires": {
+                  "archiver-utils": "^1.3.0",
+                  "async": "^2.0.0",
+                  "buffer-crc32": "^0.2.1",
+                  "glob": "^7.0.0",
+                  "lodash": "^4.8.0",
+                  "readable-stream": "^2.0.0",
+                  "tar-stream": "^1.5.0",
+                  "zip-stream": "^1.2.0"
+               }
+            },
+            "async": {
+               "version": "2.5.0",
+               "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+               "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+               "dev": true,
+               "requires": {
+                  "lodash": "^4.14.0"
+               }
+            },
+            "fs-extra": {
+               "version": "4.0.3",
+               "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+               "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+               "dev": true,
+               "requires": {
+                  "graceful-fs": "^4.1.2",
+                  "jsonfile": "^4.0.0",
+                  "universalify": "^0.1.0"
+               }
+            },
+            "jsonfile": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+               "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+               "dev": true,
+               "requires": {
+                  "graceful-fs": "^4.1.6"
+               }
+            },
+            "minimist": {
+               "version": "1.2.0",
+               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+               "dev": true
+            }
+         }
+      },
+      "first-chunk-stream": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-3.0.0.tgz",
+         "integrity": "sha512-LNRvR4hr/S8cXXkIY5pTgVP7L3tq6LlYWcg9nWBuW7o1NMxKZo6oOVa/6GIekMGI0Iw7uC+HWimMe9u/VAeKqw==",
+         "dev": true
+      },
       "flat": {
          "version": "4.1.0",
          "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
@@ -3430,10 +5252,22 @@
             "write": "1.0.3"
          }
       },
+      "flatstr": {
+         "version": "1.0.12",
+         "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+         "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
+         "dev": true
+      },
       "flatted": {
          "version": "2.0.1",
          "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
          "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+         "dev": true
+      },
+      "fluent-syntax": {
+         "version": "0.13.0",
+         "resolved": "https://registry.npmjs.org/fluent-syntax/-/fluent-syntax-0.13.0.tgz",
+         "integrity": "sha512-0Bk1AsliuYB550zr4JV9AYhsETsD3ELXUQzdXGJfIc1Ni/ukAfBdQInDhVMYJUaT2QxoamNslwkYF7MlOrPUwg==",
          "dev": true
       },
       "for-in": {
@@ -3467,6 +5301,12 @@
          "requires": {
             "map-cache": "^0.2.2"
          }
+      },
+      "fs-constants": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+         "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+         "dev": true
       },
       "fs-extra": {
          "version": "1.0.0",
@@ -4039,6 +5879,19 @@
             }
          }
       },
+      "fstream": {
+         "version": "1.0.12",
+         "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+         "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+         "dev": true,
+         "optional": true,
+         "requires": {
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
+         }
+      },
       "function-bind": {
          "version": "1.1.1",
          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -4050,6 +5903,142 @@
          "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
          "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
          "dev": true
+      },
+      "fx-runner": {
+         "version": "1.0.11",
+         "resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-1.0.11.tgz",
+         "integrity": "sha512-igHogHf5wTqqaPPTOav18MMTVq/eoeTJiw/PvPUuwnzU8vbyZInFPgR66G9ZBwvwxC7e611nbtB4xSMcYVhlvg==",
+         "dev": true,
+         "requires": {
+            "commander": "2.9.0",
+            "shell-quote": "1.6.1",
+            "spawn-sync": "1.0.15",
+            "when": "3.7.7",
+            "which": "1.2.4",
+            "winreg": "0.0.12"
+         },
+         "dependencies": {
+            "commander": {
+               "version": "2.9.0",
+               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+               "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+               "dev": true,
+               "requires": {
+                  "graceful-readlink": ">= 1.0.0"
+               }
+            },
+            "isexe": {
+               "version": "1.1.2",
+               "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+               "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+               "dev": true
+            },
+            "shell-quote": {
+               "version": "1.6.1",
+               "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+               "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+               "dev": true,
+               "requires": {
+                  "array-filter": "~0.0.0",
+                  "array-map": "~0.0.0",
+                  "array-reduce": "~0.0.0",
+                  "jsonify": "~0.0.0"
+               }
+            },
+            "which": {
+               "version": "1.2.4",
+               "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
+               "integrity": "sha1-FVf5YIBgTlsRs1meufRbUKnv1yI=",
+               "dev": true,
+               "requires": {
+                  "is-absolute": "^0.1.7",
+                  "isexe": "^1.1.1"
+               }
+            }
+         }
+      },
+      "gauge": {
+         "version": "2.7.4",
+         "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+         "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+         "dev": true,
+         "optional": true,
+         "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+         },
+         "dependencies": {
+            "ansi-regex": {
+               "version": "2.1.1",
+               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+               "dev": true,
+               "optional": true
+            },
+            "is-fullwidth-code-point": {
+               "version": "1.0.0",
+               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+               "dev": true,
+               "optional": true,
+               "requires": {
+                  "number-is-nan": "^1.0.0"
+               }
+            },
+            "object-assign": {
+               "version": "4.1.1",
+               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+               "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+               "dev": true,
+               "optional": true
+            },
+            "string-width": {
+               "version": "1.0.2",
+               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+               "dev": true,
+               "optional": true,
+               "requires": {
+                  "code-point-at": "^1.0.0",
+                  "is-fullwidth-code-point": "^1.0.0",
+                  "strip-ansi": "^3.0.0"
+               }
+            },
+            "strip-ansi": {
+               "version": "3.0.1",
+               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+               "dev": true,
+               "optional": true,
+               "requires": {
+                  "ansi-regex": "^2.0.0"
+               }
+            }
+         }
+      },
+      "generate-function": {
+         "version": "2.3.1",
+         "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+         "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+         "dev": true,
+         "requires": {
+            "is-property": "^1.0.2"
+         }
+      },
+      "generate-object-property": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+         "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+         "dev": true,
+         "requires": {
+            "is-property": "^1.0.0"
+         }
       },
       "get-assigned-identifiers": {
          "version": "1.2.0",
@@ -4099,6 +6088,52 @@
             "assert-plus": "^1.0.0"
          }
       },
+      "gettext-parser": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.1.0.tgz",
+         "integrity": "sha1-LFpmONiTk0ubVQN9CtgstwBLJnk=",
+         "dev": true,
+         "requires": {
+            "encoding": "^0.1.11"
+         }
+      },
+      "git-rev-sync": {
+         "version": "1.12.0",
+         "resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-1.12.0.tgz",
+         "integrity": "sha1-RGhAbH5sO6TPRYeZnhrbKNnRr1U=",
+         "dev": true,
+         "requires": {
+            "escape-string-regexp": "1.0.5",
+            "graceful-fs": "4.1.11",
+            "shelljs": "0.7.7"
+         },
+         "dependencies": {
+            "graceful-fs": {
+               "version": "4.1.11",
+               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+               "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+               "dev": true
+            },
+            "shelljs": {
+               "version": "0.7.7",
+               "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+               "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
+               "dev": true,
+               "requires": {
+                  "glob": "^7.0.0",
+                  "interpret": "^1.0.0",
+                  "rechoir": "^0.6.2"
+               }
+            }
+         }
+      },
+      "github-from-package": {
+         "version": "0.0.0",
+         "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+         "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+         "dev": true,
+         "optional": true
+      },
       "glob": {
          "version": "7.1.4",
          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -4139,6 +6174,15 @@
          "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
          "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
          "dev": true
+      },
+      "global-dirs": {
+         "version": "0.1.1",
+         "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+         "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+         "dev": true,
+         "requires": {
+            "ini": "^1.3.4"
+         }
       },
       "global-modules": {
          "version": "2.0.0",
@@ -4205,16 +6249,47 @@
             }
          }
       },
+      "got": {
+         "version": "9.6.0",
+         "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+         "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+         "dev": true,
+         "requires": {
+            "@sindresorhus/is": "^0.14.0",
+            "@szmarczak/http-timer": "^1.1.2",
+            "cacheable-request": "^6.0.0",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^4.1.0",
+            "lowercase-keys": "^1.0.1",
+            "mimic-response": "^1.0.1",
+            "p-cancelable": "^1.0.0",
+            "to-readable-stream": "^1.0.0",
+            "url-parse-lax": "^3.0.0"
+         }
+      },
       "graceful-fs": {
          "version": "4.2.2",
          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
          "dev": true
       },
+      "graceful-readlink": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+         "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+         "dev": true
+      },
       "growl": {
          "version": "1.10.5",
          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
          "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+         "dev": true
+      },
+      "growly": {
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+         "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
          "dev": true
       },
       "grunt": {
@@ -4326,6 +6401,62 @@
                "requires": {
                   "lodash": "^4.17.14"
                }
+            }
+         }
+      },
+      "grunt-contrib-compress": {
+         "version": "1.5.0",
+         "resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-1.5.0.tgz",
+         "integrity": "sha512-RcCyetnvTJ7jvnDCSm05wOndAd00HWZTHeVGDVVmCM+K/PEivL0yx8vKyi8uzy0492l2dJgtzR0Ucid7roKg6A==",
+         "dev": true,
+         "requires": {
+            "archiver": "^1.3.0",
+            "chalk": "^1.1.1",
+            "iltorb": "^1.3.10",
+            "lodash": "^4.7.0",
+            "pretty-bytes": "^4.0.2",
+            "stream-buffers": "^2.1.0"
+         },
+         "dependencies": {
+            "ansi-regex": {
+               "version": "2.1.1",
+               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+               "dev": true
+            },
+            "ansi-styles": {
+               "version": "2.2.1",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+               "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+               "dev": true
+            },
+            "chalk": {
+               "version": "1.1.3",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^2.2.1",
+                  "escape-string-regexp": "^1.0.2",
+                  "has-ansi": "^2.0.0",
+                  "strip-ansi": "^3.0.0",
+                  "supports-color": "^2.0.0"
+               }
+            },
+            "strip-ansi": {
+               "version": "3.0.1",
+               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+               "dev": true,
+               "requires": {
+                  "ansi-regex": "^2.0.0"
+               }
+            },
+            "supports-color": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+               "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+               "dev": true
             }
          }
       },
@@ -4967,28 +7098,24 @@
             }
          }
       },
-      "grunt-run": {
-         "version": "0.8.1",
-         "resolved": "https://registry.npmjs.org/grunt-run/-/grunt-run-0.8.1.tgz",
-         "integrity": "sha512-+wvoOJevugcjMLldbVCyspRHHntwVIJiTGjx0HFq+UwXhVPe7AaAiUdY4135CS68pAoRLhd7pAILpL2ITe1tmA==",
+      "grunt-shell": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-3.0.1.tgz",
+         "integrity": "sha512-C8eR4frw/NmIFIwSvzSLS4wOQBUzC+z6QhrKPzwt/tlaIqlzH35i/O2MggVOBj2Sh1tbaAqpASWxGiGsi4JMIQ==",
          "dev": true,
          "requires": {
-            "strip-ansi": "^3.0.0"
+            "chalk": "^2.4.1",
+            "npm-run-path": "^2.0.0",
+            "strip-ansi": "^5.0.0"
          },
          "dependencies": {
-            "ansi-regex": {
-               "version": "2.1.1",
-               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-               "dev": true
-            },
             "strip-ansi": {
-               "version": "3.0.1",
-               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+               "version": "5.2.0",
+               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                "dev": true,
                "requires": {
-                  "ansi-regex": "^2.0.0"
+                  "ansi-regex": "^4.1.0"
                }
             }
          }
@@ -5044,6 +7171,12 @@
             }
          }
       },
+      "has-color": {
+         "version": "0.1.7",
+         "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+         "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+         "dev": true
+      },
       "has-flag": {
          "version": "3.0.0",
          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -5055,6 +7188,13 @@
          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
          "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
          "dev": true
+      },
+      "has-unicode": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+         "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+         "dev": true,
+         "optional": true
       },
       "has-value": {
          "version": "1.0.0",
@@ -5087,6 +7227,12 @@
                }
             }
          }
+      },
+      "has-yarn": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+         "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+         "dev": true
       },
       "hash-base": {
          "version": "3.0.4",
@@ -5204,6 +7350,12 @@
             }
          }
       },
+      "http-cache-semantics": {
+         "version": "4.0.3",
+         "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
+         "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
+         "dev": true
+      },
       "http-signature": {
          "version": "1.2.0",
          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -5241,6 +7393,19 @@
          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
          "dev": true
+      },
+      "iltorb": {
+         "version": "1.3.10",
+         "resolved": "https://registry.npmjs.org/iltorb/-/iltorb-1.3.10.tgz",
+         "integrity": "sha512-nyB4+ru1u8CQqQ6w7YjasboKN3NQTN8GH/V/eEssNRKhW6UbdxdWhB9fJ5EEdjJfezKY0qPrcwLyIcgjL8hHxA==",
+         "dev": true,
+         "optional": true,
+         "requires": {
+            "detect-libc": "^0.2.0",
+            "nan": "^2.6.2",
+            "node-gyp": "^3.6.2",
+            "prebuild-install": "^2.3.0"
+         }
       },
       "image-size": {
          "version": "0.5.5",
@@ -5367,6 +7532,12 @@
             "xtend": "^4.0.0"
          }
       },
+      "interpret": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+         "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+         "dev": true
+      },
       "invariant": {
          "version": "2.2.4",
          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -5387,6 +7558,15 @@
          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
          "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
          "dev": true
+      },
+      "is-absolute": {
+         "version": "0.1.7",
+         "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+         "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
+         "dev": true,
+         "requires": {
+            "is-relative": "^0.1.0"
+         }
       },
       "is-accessor-descriptor": {
          "version": "0.1.6",
@@ -5430,6 +7610,12 @@
             "is-decimal": "^1.0.0"
          }
       },
+      "is-arguments": {
+         "version": "1.0.4",
+         "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+         "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+         "dev": true
+      },
       "is-arrayish": {
          "version": "0.2.1",
          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -5456,6 +7642,15 @@
          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
          "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
          "dev": true
+      },
+      "is-ci": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+         "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+         "dev": true,
+         "requires": {
+            "ci-info": "^2.0.0"
+         }
       },
       "is-data-descriptor": {
          "version": "0.1.4",
@@ -5556,6 +7751,47 @@
          "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==",
          "dev": true
       },
+      "is-installed-globally": {
+         "version": "0.1.0",
+         "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+         "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+         "dev": true,
+         "requires": {
+            "global-dirs": "^0.1.0",
+            "is-path-inside": "^1.0.0"
+         }
+      },
+      "is-mergeable-object": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/is-mergeable-object/-/is-mergeable-object-1.1.1.tgz",
+         "integrity": "sha512-CPduJfuGg8h8vW74WOxHtHmtQutyQBzR+3MjQ6iDHIYdbOnm1YC7jv43SqCoU8OPGTJD4nibmiryA4kmogbGrA==",
+         "dev": true
+      },
+      "is-my-ip-valid": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+         "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+         "dev": true
+      },
+      "is-my-json-valid": {
+         "version": "2.20.0",
+         "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.0.tgz",
+         "integrity": "sha512-XTHBZSIIxNsIsZXg7XB5l8z/OBFosl1Wao4tXLpeC7eKU4Vm/kdop2azkPqULwnfGQjmeDIyey9g7afMMtdWAA==",
+         "dev": true,
+         "requires": {
+            "generate-function": "^2.0.0",
+            "generate-object-property": "^1.1.0",
+            "is-my-ip-valid": "^1.0.0",
+            "jsonpointer": "^4.0.0",
+            "xtend": "^4.0.0"
+         }
+      },
+      "is-npm": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
+         "integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA==",
+         "dev": true
+      },
       "is-number": {
          "version": "3.0.0",
          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -5582,6 +7818,15 @@
          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
          "dev": true
       },
+      "is-path-inside": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+         "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+         "dev": true,
+         "requires": {
+            "path-is-inside": "^1.0.1"
+         }
+      },
       "is-plain-obj": {
          "version": "1.1.0",
          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -5603,6 +7848,12 @@
          "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
          "dev": true
       },
+      "is-property": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+         "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+         "dev": true
+      },
       "is-regex": {
          "version": "1.0.4",
          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -5616,6 +7867,12 @@
          "version": "2.1.0",
          "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
          "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
+         "dev": true
+      },
+      "is-relative": {
+         "version": "0.1.3",
+         "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+         "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
          "dev": true
       },
       "is-resolvable": {
@@ -5675,6 +7932,18 @@
          "integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==",
          "dev": true
       },
+      "is-wsl": {
+         "version": "2.1.1",
+         "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+         "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
+         "dev": true
+      },
+      "is-yarn-global": {
+         "version": "0.3.0",
+         "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+         "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+         "dev": true
+      },
       "isarray": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -5699,6 +7968,18 @@
          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
          "dev": true
       },
+      "jed": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/jed/-/jed-1.1.1.tgz",
+         "integrity": "sha1-elSbvZ/+FYWwzQoZHiAwVb7ldLQ=",
+         "dev": true
+      },
+      "jetpack-id": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-1.0.0.tgz",
+         "integrity": "sha1-LPn7rkbYB0/Ba33gBxyO/rykc6Y=",
+         "dev": true
+      },
       "jquery": {
          "version": "3.4.1",
          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
@@ -5710,6 +7991,16 @@
          "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
          "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
          "dev": true
+      },
+      "js-select": {
+         "version": "0.6.0",
+         "resolved": "https://registry.npmjs.org/js-select/-/js-select-0.6.0.tgz",
+         "integrity": "sha1-woTiKCTVknrsli3N8kcXSu+w0ZA=",
+         "dev": true,
+         "requires": {
+            "JSONSelect": "0.2.1",
+            "traverse": "0.4.x"
+         }
       },
       "js-tokens": {
          "version": "4.0.0",
@@ -5851,6 +8142,21 @@
          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
          "dev": true
       },
+      "json-buffer": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+         "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+         "dev": true
+      },
+      "json-merge-patch": {
+         "version": "0.2.3",
+         "resolved": "https://registry.npmjs.org/json-merge-patch/-/json-merge-patch-0.2.3.tgz",
+         "integrity": "sha1-+ixrWvh9p3uuKWalidUuI+2B/kA=",
+         "dev": true,
+         "requires": {
+            "deep-equal": "^1.0.0"
+         }
+      },
       "json-parse-better-errors": {
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -5928,6 +8234,38 @@
          "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
          "dev": true
       },
+      "jsonpointer": {
+         "version": "4.0.1",
+         "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+         "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+         "dev": true
+      },
+      "jsonwebtoken": {
+         "version": "8.2.1",
+         "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
+         "integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
+         "dev": true,
+         "requires": {
+            "jws": "^3.1.4",
+            "lodash.includes": "^4.3.0",
+            "lodash.isboolean": "^3.0.3",
+            "lodash.isinteger": "^4.0.4",
+            "lodash.isnumber": "^3.0.3",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.isstring": "^4.0.1",
+            "lodash.once": "^4.0.0",
+            "ms": "^2.1.1",
+            "xtend": "^4.0.1"
+         },
+         "dependencies": {
+            "ms": {
+               "version": "2.1.2",
+               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+               "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+               "dev": true
+            }
+         }
+      },
       "jsprim": {
          "version": "1.4.1",
          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5940,11 +8278,50 @@
             "verror": "1.10.0"
          }
       },
+      "jszip": {
+         "version": "2.6.1",
+         "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
+         "integrity": "sha1-uI86ey5noqBIFSmCx6N1bZxIKPA=",
+         "dev": true,
+         "requires": {
+            "pako": "~1.0.2"
+         }
+      },
+      "jwa": {
+         "version": "1.4.1",
+         "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+         "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+         "dev": true,
+         "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+         }
+      },
+      "jws": {
+         "version": "3.2.2",
+         "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+         "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+         "dev": true,
+         "requires": {
+            "jwa": "^1.4.1",
+            "safe-buffer": "^5.0.1"
+         }
+      },
       "kew": {
          "version": "0.7.0",
          "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
          "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
          "dev": true
+      },
+      "keyv": {
+         "version": "3.1.0",
+         "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+         "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+         "dev": true,
+         "requires": {
+            "json-buffer": "3.0.0"
+         }
       },
       "kind-of": {
          "version": "6.0.2",
@@ -5975,6 +8352,24 @@
          "requires": {
             "inherits": "^2.0.1",
             "stream-splicer": "^2.0.0"
+         }
+      },
+      "latest-version": {
+         "version": "5.1.0",
+         "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+         "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+         "dev": true,
+         "requires": {
+            "package-json": "^6.3.0"
+         }
+      },
+      "lazystream": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+         "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+         "dev": true,
+         "requires": {
+            "readable-stream": "^2.0.5"
          }
       },
       "lcid": {
@@ -6027,6 +8422,22 @@
             "prelude-ls": "~1.1.2",
             "type-check": "~0.3.2"
          }
+      },
+      "lighthouse-logger": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz",
+         "integrity": "sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==",
+         "dev": true,
+         "requires": {
+            "debug": "^2.6.8",
+            "marky": "^1.2.0"
+         }
+      },
+      "lines-and-columns": {
+         "version": "1.1.6",
+         "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+         "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+         "dev": true
       },
       "linkify-it": {
          "version": "2.2.0",
@@ -6100,10 +8511,52 @@
          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
          "dev": true
       },
+      "lodash.includes": {
+         "version": "4.3.0",
+         "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+         "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+         "dev": true
+      },
+      "lodash.isboolean": {
+         "version": "3.0.3",
+         "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+         "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+         "dev": true
+      },
+      "lodash.isinteger": {
+         "version": "4.0.4",
+         "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+         "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+         "dev": true
+      },
+      "lodash.isnumber": {
+         "version": "3.0.3",
+         "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+         "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
+         "dev": true
+      },
+      "lodash.isplainobject": {
+         "version": "4.0.6",
+         "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+         "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+         "dev": true
+      },
+      "lodash.isstring": {
+         "version": "4.0.1",
+         "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+         "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+         "dev": true
+      },
       "lodash.memoize": {
          "version": "3.0.4",
          "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
          "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
+         "dev": true
+      },
+      "lodash.once": {
+         "version": "4.1.1",
+         "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+         "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
          "dev": true
       },
       "lodash.sortby": {
@@ -6145,6 +8598,12 @@
             "currently-unhandled": "^0.4.1",
             "signal-exit": "^3.0.0"
          }
+      },
+      "lowercase-keys": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+         "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+         "dev": true
       },
       "lru-cache": {
          "version": "4.1.5",
@@ -6239,6 +8698,12 @@
          "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
          "dev": true
       },
+      "marky": {
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.1.tgz",
+         "integrity": "sha512-md9k+Gxa3qLH6sUKpeC2CNkJK/Ld+bEz5X96nYwloqphQE0CKCVEKco/6jxEZixinqNdz5RFi/KaCyfbMDMAXQ==",
+         "dev": true
+      },
       "mathml-tag-names": {
          "version": "2.1.1",
          "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.1.tgz",
@@ -6263,6 +8728,15 @@
          "dev": true,
          "requires": {
             "unist-util-visit": "^1.1.0"
+         }
+      },
+      "mdn-browser-compat-data": {
+         "version": "0.0.94",
+         "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.94.tgz",
+         "integrity": "sha512-O3zJqbmehz0Hn3wpk62taA0+jNF7yn6BDWqQ9Wh2bEoO9Rx1BYiTmNX565eNVbW0ixfQkY6Sp9FvY/rr79Qmyg==",
+         "dev": true,
+         "requires": {
+            "extend": "3.0.2"
          }
       },
       "mdurl": {
@@ -6377,6 +8851,12 @@
          "version": "2.1.0",
          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+         "dev": true
+      },
+      "mimic-response": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+         "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
          "dev": true
       },
       "minimalistic-assert": {
@@ -6550,17 +9030,108 @@
             "xtend": "^4.0.0"
          }
       },
+      "moment": {
+         "version": "2.24.0",
+         "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+         "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+         "dev": true,
+         "optional": true
+      },
       "ms": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
          "dev": true
       },
+      "multimatch": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+         "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
+         "dev": true,
+         "requires": {
+            "@types/minimatch": "^3.0.3",
+            "array-differ": "^3.0.0",
+            "array-union": "^2.1.0",
+            "arrify": "^2.0.1",
+            "minimatch": "^3.0.4"
+         },
+         "dependencies": {
+            "array-union": {
+               "version": "2.1.0",
+               "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+               "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+               "dev": true
+            },
+            "arrify": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+               "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+               "dev": true
+            }
+         }
+      },
       "mute-stream": {
          "version": "0.0.8",
          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
          "dev": true
+      },
+      "mv": {
+         "version": "2.1.1",
+         "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+         "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+         "dev": true,
+         "optional": true,
+         "requires": {
+            "mkdirp": "~0.5.1",
+            "ncp": "~2.0.0",
+            "rimraf": "~2.4.0"
+         },
+         "dependencies": {
+            "glob": {
+               "version": "6.0.4",
+               "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+               "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+               "dev": true,
+               "optional": true,
+               "requires": {
+                  "inflight": "^1.0.4",
+                  "inherits": "2",
+                  "minimatch": "2 || 3",
+                  "once": "^1.3.0",
+                  "path-is-absolute": "^1.0.0"
+               }
+            },
+            "rimraf": {
+               "version": "2.4.5",
+               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+               "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+               "dev": true,
+               "optional": true,
+               "requires": {
+                  "glob": "^6.0.1"
+               }
+            }
+         }
+      },
+      "mz": {
+         "version": "2.7.0",
+         "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+         "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+         "dev": true,
+         "requires": {
+            "any-promise": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "thenify-all": "^1.0.0"
+         },
+         "dependencies": {
+            "object-assign": {
+               "version": "4.1.1",
+               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+               "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+               "dev": true
+            }
+         }
       },
       "nan": {
          "version": "2.14.0",
@@ -6594,11 +9165,46 @@
          "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
          "dev": true
       },
+      "natural-compare-lite": {
+         "version": "1.4.0",
+         "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+         "integrity": "sha1-F7CVgZiJef3a/gIB6TG6kzyWy7Q=",
+         "dev": true
+      },
+      "ncp": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+         "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+         "dev": true,
+         "optional": true
+      },
+      "neo-async": {
+         "version": "2.6.1",
+         "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+         "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+         "dev": true
+      },
+      "next-tick": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+         "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+         "dev": true
+      },
       "nice-try": {
          "version": "1.0.5",
          "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
          "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
          "dev": true
+      },
+      "node-abi": {
+         "version": "2.11.0",
+         "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.11.0.tgz",
+         "integrity": "sha512-kuy/aEg75u40v378WRllQ4ZexaXJiCvB68D2scDXclp/I4cRq6togpbOoKhmN07tns9Zldu51NNERo0wehfX9g==",
+         "dev": true,
+         "optional": true,
+         "requires": {
+            "semver": "^5.4.1"
+         }
       },
       "node-environment-flags": {
          "version": "1.0.6",
@@ -6610,11 +9216,68 @@
             "semver": "^5.7.0"
          }
       },
+      "node-forge": {
+         "version": "0.7.6",
+         "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+         "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==",
+         "dev": true
+      },
+      "node-gyp": {
+         "version": "3.8.0",
+         "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+         "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+         "dev": true,
+         "optional": true,
+         "requires": {
+            "fstream": "^1.0.0",
+            "glob": "^7.0.3",
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "^0.5.0",
+            "nopt": "2 || 3",
+            "npmlog": "0 || 1 || 2 || 3 || 4",
+            "osenv": "0",
+            "request": "^2.87.0",
+            "rimraf": "2",
+            "semver": "~5.3.0",
+            "tar": "^2.0.0",
+            "which": "1"
+         },
+         "dependencies": {
+            "semver": {
+               "version": "5.3.0",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+               "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+               "dev": true,
+               "optional": true
+            }
+         }
+      },
       "node-modules-regexp": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
          "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
          "dev": true
+      },
+      "node-notifier": {
+         "version": "6.0.0",
+         "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-6.0.0.tgz",
+         "integrity": "sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==",
+         "dev": true,
+         "requires": {
+            "growly": "^1.3.0",
+            "is-wsl": "^2.1.1",
+            "semver": "^6.3.0",
+            "shellwords": "^0.1.1",
+            "which": "^1.3.1"
+         },
+         "dependencies": {
+            "semver": {
+               "version": "6.3.0",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+               "dev": true
+            }
+         }
       },
       "node-releases": {
          "version": "1.1.27",
@@ -6624,6 +9287,54 @@
          "requires": {
             "semver": "^5.3.0"
          }
+      },
+      "nomnom": {
+         "version": "1.8.1",
+         "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+         "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+         "dev": true,
+         "requires": {
+            "chalk": "~0.4.0",
+            "underscore": "~1.6.0"
+         },
+         "dependencies": {
+            "ansi-styles": {
+               "version": "1.0.0",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+               "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+               "dev": true
+            },
+            "chalk": {
+               "version": "0.4.0",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+               "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "~1.0.0",
+                  "has-color": "~0.1.0",
+                  "strip-ansi": "~0.1.0"
+               }
+            },
+            "strip-ansi": {
+               "version": "0.1.1",
+               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+               "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+               "dev": true
+            },
+            "underscore": {
+               "version": "1.6.0",
+               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+               "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+               "dev": true
+            }
+         }
+      },
+      "noop-logger": {
+         "version": "0.1.1",
+         "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+         "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
+         "dev": true,
+         "optional": true
       },
       "nopt": {
          "version": "3.0.6",
@@ -6664,6 +9375,12 @@
          "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
          "dev": true
       },
+      "normalize-url": {
+         "version": "4.5.0",
+         "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+         "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+         "dev": true
+      },
       "npm-run-path": {
          "version": "2.0.2",
          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -6671,6 +9388,28 @@
          "dev": true,
          "requires": {
             "path-key": "^2.0.0"
+         }
+      },
+      "npmlog": {
+         "version": "4.1.2",
+         "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+         "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+         "dev": true,
+         "optional": true,
+         "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+         }
+      },
+      "nth-check": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+         "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+         "dev": true,
+         "requires": {
+            "boolbase": "~1.0.0"
          }
       },
       "num2fraction": {
@@ -6733,6 +9472,12 @@
                }
             }
          }
+      },
+      "object-is": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+         "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+         "dev": true
       },
       "object-keys": {
          "version": "1.1.1",
@@ -6798,6 +9543,23 @@
             "mimic-fn": "^2.1.0"
          }
       },
+      "open": {
+         "version": "6.4.0",
+         "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+         "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+         "dev": true,
+         "requires": {
+            "is-wsl": "^1.1.0"
+         },
+         "dependencies": {
+            "is-wsl": {
+               "version": "1.1.0",
+               "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+               "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+               "dev": true
+            }
+         }
+      },
       "optionator": {
          "version": "0.8.2",
          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -6818,6 +9580,12 @@
          "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
          "dev": true
       },
+      "os-homedir": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+         "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+         "dev": true
+      },
       "os-locale": {
          "version": "3.1.0",
          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
@@ -6829,11 +9597,28 @@
             "mem": "^4.0.0"
          }
       },
+      "os-shim": {
+         "version": "0.1.3",
+         "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+         "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
+         "dev": true
+      },
       "os-tmpdir": {
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
          "dev": true
+      },
+      "osenv": {
+         "version": "0.1.5",
+         "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+         "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+         "dev": true,
+         "optional": true,
+         "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+         }
       },
       "outpipe": {
          "version": "1.1.1",
@@ -6854,6 +9639,12 @@
             "is-plain-obj": "^1.1.0",
             "mkdirp": "^0.5.1"
          }
+      },
+      "p-cancelable": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+         "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+         "dev": true
       },
       "p-defer": {
          "version": "1.0.0",
@@ -6902,6 +9693,26 @@
          "resolved": "https://registry.npmjs.org/package/-/package-1.0.1.tgz",
          "integrity": "sha1-0lofmeJQbcsn1nBLg9yooxLk7cw=",
          "dev": true
+      },
+      "package-json": {
+         "version": "6.5.0",
+         "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+         "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+         "dev": true,
+         "requires": {
+            "got": "^9.6.0",
+            "registry-auth-token": "^4.0.0",
+            "registry-url": "^5.0.0",
+            "semver": "^6.2.0"
+         },
+         "dependencies": {
+            "semver": {
+               "version": "6.3.0",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+               "dev": true
+            }
+         }
       },
       "pako": {
          "version": "1.0.10",
@@ -7126,6 +9937,26 @@
             "pinkie": "^2.0.0"
          }
       },
+      "pino": {
+         "version": "5.13.3",
+         "resolved": "https://registry.npmjs.org/pino/-/pino-5.13.3.tgz",
+         "integrity": "sha512-FL12DKlPwBlbhztlUz6kseR03PRR8nD+wvLdN/Sji9UiBYYfSjX+k8ocU7/NwW55JdFRONTn3iACoelXnMFVVQ==",
+         "dev": true,
+         "requires": {
+            "fast-redact": "^1.4.4",
+            "fast-safe-stringify": "^2.0.7",
+            "flatstr": "^1.0.9",
+            "pino-std-serializers": "^2.3.0",
+            "quick-format-unescaped": "^3.0.2",
+            "sonic-boom": "^0.7.5"
+         }
+      },
+      "pino-std-serializers": {
+         "version": "2.4.2",
+         "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
+         "integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ==",
+         "dev": true
+      },
       "pirates": {
          "version": "4.0.1",
          "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -7155,6 +9986,16 @@
          "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
          "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
          "dev": true
+      },
+      "po2json": {
+         "version": "0.4.5",
+         "resolved": "https://registry.npmjs.org/po2json/-/po2json-0.4.5.tgz",
+         "integrity": "sha1-R7spUtoy1Yob4vJWpZjuvAt0URg=",
+         "dev": true,
+         "requires": {
+            "gettext-parser": "1.1.0",
+            "nomnom": "1.8.1"
+         }
       },
       "posix-character-classes": {
          "version": "0.1.1",
@@ -7302,10 +10143,73 @@
          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
          "dev": true
       },
+      "prebuild-install": {
+         "version": "2.5.3",
+         "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
+         "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
+         "dev": true,
+         "optional": true,
+         "requires": {
+            "detect-libc": "^1.0.3",
+            "expand-template": "^1.0.2",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "node-abi": "^2.2.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "os-homedir": "^1.0.1",
+            "pump": "^2.0.1",
+            "rc": "^1.1.6",
+            "simple-get": "^2.7.0",
+            "tar-fs": "^1.13.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
+         },
+         "dependencies": {
+            "detect-libc": {
+               "version": "1.0.3",
+               "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+               "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+               "dev": true,
+               "optional": true
+            },
+            "minimist": {
+               "version": "1.2.0",
+               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+               "dev": true,
+               "optional": true
+            },
+            "pump": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+               "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+               "dev": true,
+               "optional": true,
+               "requires": {
+                  "end-of-stream": "^1.1.0",
+                  "once": "^1.3.1"
+               }
+            }
+         }
+      },
       "prelude-ls": {
          "version": "1.1.2",
          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+         "dev": true
+      },
+      "prepend-http": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+         "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+         "dev": true
+      },
+      "pretty-bytes": {
+         "version": "4.0.2",
+         "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+         "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
          "dev": true
       },
       "private": {
@@ -7313,6 +10217,19 @@
          "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
          "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
          "dev": true
+      },
+      "probe-image-size": {
+         "version": "5.0.0",
+         "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-5.0.0.tgz",
+         "integrity": "sha512-V6uBYw5eBc5UVIE7MUZD6Nxg0RYuGDWLDenEn0B1WC6PcTvn1xdQ6HLDDuznefsiExC6rNrCz7mFRBo0f3Xekg==",
+         "dev": true,
+         "requires": {
+            "deepmerge": "^4.0.0",
+            "inherits": "^2.0.3",
+            "next-tick": "^1.0.0",
+            "request": "^2.83.0",
+            "stream-parser": "~0.3.1"
+         }
       },
       "process": {
          "version": "0.11.10",
@@ -7409,6 +10326,12 @@
          "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
          "dev": true
       },
+      "quick-format-unescaped": {
+         "version": "3.0.3",
+         "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
+         "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ==",
+         "dev": true
+      },
       "quick-lru": {
          "version": "1.1.0",
          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
@@ -7432,6 +10355,26 @@
          "requires": {
             "randombytes": "^2.0.5",
             "safe-buffer": "^5.1.0"
+         }
+      },
+      "rc": {
+         "version": "1.2.8",
+         "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+         "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+         "dev": true,
+         "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+         },
+         "dependencies": {
+            "minimist": {
+               "version": "1.2.0",
+               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+               "dev": true
+            }
          }
       },
       "read-only-stream": {
@@ -7511,6 +10454,43 @@
             "readable-stream": "^2.0.2"
          }
       },
+      "readline2": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+         "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+         "dev": true,
+         "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "mute-stream": "0.0.5"
+         },
+         "dependencies": {
+            "is-fullwidth-code-point": {
+               "version": "1.0.0",
+               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+               "dev": true,
+               "requires": {
+                  "number-is-nan": "^1.0.0"
+               }
+            },
+            "mute-stream": {
+               "version": "0.0.5",
+               "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+               "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+               "dev": true
+            }
+         }
+      },
+      "rechoir": {
+         "version": "0.6.2",
+         "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+         "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+         "dev": true,
+         "requires": {
+            "resolve": "^1.1.6"
+         }
+      },
       "redent": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -7566,6 +10546,15 @@
          "integrity": "sha512-7/l/DgapVVDzZobwMCCgMlqiqyLFJ0cduo/j+3BcDJIB+yJdsYCfKuI3l/04NV+H/rfNRdPIDbXNZHM9XvQatg==",
          "dev": true
       },
+      "regexp.prototype.flags": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+         "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+         "dev": true,
+         "requires": {
+            "define-properties": "^1.1.2"
+         }
+      },
       "regexpp": {
          "version": "2.0.1",
          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -7584,6 +10573,25 @@
             "regjsparser": "^0.6.0",
             "unicode-match-property-ecmascript": "^1.0.4",
             "unicode-match-property-value-ecmascript": "^1.1.0"
+         }
+      },
+      "registry-auth-token": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
+         "integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
+         "dev": true,
+         "requires": {
+            "rc": "^1.2.8",
+            "safe-buffer": "^5.0.1"
+         }
+      },
+      "registry-url": {
+         "version": "5.1.0",
+         "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+         "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+         "dev": true,
+         "requires": {
+            "rc": "^1.2.8"
          }
       },
       "regjsgen": {
@@ -7607,6 +10615,16 @@
                "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
                "dev": true
             }
+         }
+      },
+      "relaxed-json": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/relaxed-json/-/relaxed-json-1.0.3.tgz",
+         "integrity": "sha512-b7wGPo7o2KE/g7SqkJDDbav6zmrEeP4TK2VpITU72J/M949TLe/23y/ZHJo+pskcGM52xIfFoT9hydwmgr1AEg==",
+         "dev": true,
+         "requires": {
+            "chalk": "^2.4.2",
+            "commander": "^2.6.0"
          }
       },
       "remark": {
@@ -7815,6 +10833,15 @@
          "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
          "dev": true
       },
+      "responselike": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+         "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+         "dev": true,
+         "requires": {
+            "lowercase-keys": "^1.0.0"
+         }
+      },
       "restore-cursor": {
          "version": "3.1.0",
          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -7889,6 +10916,13 @@
          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
          "dev": true
       },
+      "safe-json-stringify": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+         "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+         "dev": true,
+         "optional": true
+      },
       "safe-regex": {
          "version": "1.1.0",
          "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
@@ -7902,6 +10936,12 @@
          "version": "2.1.2",
          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+         "dev": true
+      },
+      "sax": {
+         "version": "1.2.4",
+         "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+         "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
          "dev": true
       },
       "saxes": {
@@ -7918,6 +10958,15 @@
          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
          "dev": true
+      },
+      "semver-diff": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+         "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+         "dev": true,
+         "requires": {
+            "semver": "^5.0.3"
+         }
       },
       "set-blocking": {
          "version": "2.0.0",
@@ -7989,6 +11038,167 @@
          "integrity": "sha512-2kUqeAGnMAu6YrTPX4E3LfxacH9gKljzVjlkUeSqY0soGwK4KLl7TURXCem712tkhBCeeaFP9QK4dKn88s3Icg==",
          "dev": true
       },
+      "shelljs": {
+         "version": "0.7.8",
+         "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+         "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+         "dev": true,
+         "requires": {
+            "glob": "^7.0.0",
+            "interpret": "^1.0.0",
+            "rechoir": "^0.6.2"
+         }
+      },
+      "shellwords": {
+         "version": "0.1.1",
+         "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+         "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+         "dev": true
+      },
+      "sign-addon": {
+         "version": "0.3.1",
+         "resolved": "https://registry.npmjs.org/sign-addon/-/sign-addon-0.3.1.tgz",
+         "integrity": "sha512-feaoG7+8IXr9SymOEd8VTZCSlVZArWcBDZ33IIdfXlU5NWWzXdCxCjPDqAkLQplFa7RRZr1S4lSmgMPn80Ze1A==",
+         "dev": true,
+         "requires": {
+            "babel-polyfill": "6.16.0",
+            "deepcopy": "0.6.3",
+            "es6-error": "4.0.0",
+            "es6-promisify": "5.0.0",
+            "jsonwebtoken": "8.2.1",
+            "mz": "2.5.0",
+            "request": "2.87.0",
+            "source-map-support": "0.4.6",
+            "stream-to-promise": "2.2.0",
+            "when": "3.7.7"
+         },
+         "dependencies": {
+            "ajv": {
+               "version": "5.5.2",
+               "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+               "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+               "dev": true,
+               "requires": {
+                  "co": "^4.6.0",
+                  "fast-deep-equal": "^1.0.0",
+                  "fast-json-stable-stringify": "^2.0.0",
+                  "json-schema-traverse": "^0.3.0"
+               }
+            },
+            "es6-error": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.0.0.tgz",
+               "integrity": "sha1-8JTHBB9mJZm7EnINoFnWucf/D0A=",
+               "dev": true
+            },
+            "es6-promisify": {
+               "version": "5.0.0",
+               "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+               "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+               "dev": true,
+               "requires": {
+                  "es6-promise": "^4.0.3"
+               }
+            },
+            "fast-deep-equal": {
+               "version": "1.1.0",
+               "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+               "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+               "dev": true
+            },
+            "har-validator": {
+               "version": "5.0.3",
+               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+               "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+               "dev": true,
+               "requires": {
+                  "ajv": "^5.1.0",
+                  "har-schema": "^2.0.0"
+               }
+            },
+            "json-schema-traverse": {
+               "version": "0.3.1",
+               "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+               "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+               "dev": true
+            },
+            "mz": {
+               "version": "2.5.0",
+               "resolved": "https://registry.npmjs.org/mz/-/mz-2.5.0.tgz",
+               "integrity": "sha1-KFkCXfA9RrV7sxcXSxlkd85kzsE=",
+               "dev": true,
+               "requires": {
+                  "any-promise": "^1.0.0",
+                  "object-assign": "^4.0.1",
+                  "thenify-all": "^1.0.0"
+               }
+            },
+            "oauth-sign": {
+               "version": "0.8.2",
+               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+               "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+               "dev": true
+            },
+            "object-assign": {
+               "version": "4.1.1",
+               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+               "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+               "dev": true
+            },
+            "punycode": {
+               "version": "1.4.1",
+               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+               "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+               "dev": true
+            },
+            "request": {
+               "version": "2.87.0",
+               "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+               "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+               "dev": true,
+               "requires": {
+                  "aws-sign2": "~0.7.0",
+                  "aws4": "^1.6.0",
+                  "caseless": "~0.12.0",
+                  "combined-stream": "~1.0.5",
+                  "extend": "~3.0.1",
+                  "forever-agent": "~0.6.1",
+                  "form-data": "~2.3.1",
+                  "har-validator": "~5.0.3",
+                  "http-signature": "~1.2.0",
+                  "is-typedarray": "~1.0.0",
+                  "isstream": "~0.1.2",
+                  "json-stringify-safe": "~5.0.1",
+                  "mime-types": "~2.1.17",
+                  "oauth-sign": "~0.8.2",
+                  "performance-now": "^2.1.0",
+                  "qs": "~6.5.1",
+                  "safe-buffer": "^5.1.1",
+                  "tough-cookie": "~2.3.3",
+                  "tunnel-agent": "^0.6.0",
+                  "uuid": "^3.1.0"
+               }
+            },
+            "source-map-support": {
+               "version": "0.4.6",
+               "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.6.tgz",
+               "integrity": "sha1-MlUqpktFg5KoXqs7C17mFScWeus=",
+               "dev": true,
+               "requires": {
+                  "source-map": "^0.5.3"
+               }
+            },
+            "tough-cookie": {
+               "version": "2.3.4",
+               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+               "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+               "dev": true,
+               "requires": {
+                  "punycode": "^1.4.1"
+               }
+            }
+         }
+      },
       "signal-exit": {
          "version": "3.0.2",
          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -8000,6 +11210,18 @@
          "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
          "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
          "dev": true
+      },
+      "simple-get": {
+         "version": "2.8.1",
+         "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+         "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+         "dev": true,
+         "optional": true,
+         "requires": {
+            "decompress-response": "^3.3.0",
+            "once": "^1.3.1",
+            "simple-concat": "^1.0.0"
+         }
       },
       "slash": {
          "version": "2.0.0",
@@ -8133,6 +11355,15 @@
             }
          }
       },
+      "sonic-boom": {
+         "version": "0.7.6",
+         "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.6.tgz",
+         "integrity": "sha512-k9E2QQ4zxuVRLDW+ZW6ISzJs3wlEorVdmM7ApDgor7wsGKSDG5YGHsGmgLY4XYh4DMlr/2ap2BWAE7yTFJtWnQ==",
+         "dev": true,
+         "requires": {
+            "flatstr": "^1.0.12"
+         }
+      },
       "source-map": {
          "version": "0.5.7",
          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -8176,6 +11407,16 @@
          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
          "dev": true
       },
+      "spawn-sync": {
+         "version": "1.0.15",
+         "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+         "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+         "dev": true,
+         "requires": {
+            "concat-stream": "^1.4.7",
+            "os-shim": "^0.1.2"
+         }
+      },
       "spdx-correct": {
          "version": "3.1.0",
          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -8213,6 +11454,15 @@
          "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
          "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
          "dev": true
+      },
+      "split": {
+         "version": "0.3.3",
+         "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+         "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+         "dev": true,
+         "requires": {
+            "through": "2"
+         }
       },
       "split-string": {
          "version": "3.1.0",
@@ -8289,6 +11539,12 @@
             "readable-stream": "^2.0.2"
          }
       },
+      "stream-buffers": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+         "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
+         "dev": true
+      },
       "stream-combiner2": {
          "version": "1.1.1",
          "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -8324,6 +11580,15 @@
             }
          }
       },
+      "stream-parser": {
+         "version": "0.3.1",
+         "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+         "integrity": "sha1-FhhUhpRCACGhGC/wrxkRwSl2F3M=",
+         "dev": true,
+         "requires": {
+            "debug": "2"
+         }
+      },
       "stream-splicer": {
          "version": "2.0.1",
          "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.1.tgz",
@@ -8332,6 +11597,46 @@
          "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.2"
+         }
+      },
+      "stream-to-array": {
+         "version": "2.3.0",
+         "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
+         "integrity": "sha1-u/azn19D7DC8cbq8s3VXrOzzQ1M=",
+         "dev": true,
+         "requires": {
+            "any-promise": "^1.1.0"
+         }
+      },
+      "stream-to-promise": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/stream-to-promise/-/stream-to-promise-2.2.0.tgz",
+         "integrity": "sha1-se2y4cjLESidG1A8CNPyrvUeZQ8=",
+         "dev": true,
+         "requires": {
+            "any-promise": "~1.3.0",
+            "end-of-stream": "~1.1.0",
+            "stream-to-array": "~2.3.0"
+         },
+         "dependencies": {
+            "end-of-stream": {
+               "version": "1.1.0",
+               "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+               "integrity": "sha1-6TUyWLqpEIll78QcsO+K3i88+wc=",
+               "dev": true,
+               "requires": {
+                  "once": "~1.3.0"
+               }
+            },
+            "once": {
+               "version": "1.3.3",
+               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+               "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+               "dev": true,
+               "requires": {
+                  "wrappy": "1"
+               }
+            }
          }
       },
       "string-width": {
@@ -8401,6 +11706,25 @@
          "dev": true,
          "requires": {
             "is-utf8": "^0.2.0"
+         }
+      },
+      "strip-bom-buf": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-2.0.0.tgz",
+         "integrity": "sha512-gLFNHucd6gzb8jMsl5QmZ3QgnUJmp7qn4uUSHNwEXumAp7YizoGYw19ZUVfuq4aBOQUtyn2k8X/CwzWB73W2lQ==",
+         "dev": true,
+         "requires": {
+            "is-utf8": "^0.2.1"
+         }
+      },
+      "strip-bom-stream": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-4.0.0.tgz",
+         "integrity": "sha512-0ApK3iAkHv6WbgLICw/J4nhwHeDZsBxIIsOD+gHgZICL6SeJ0S9f/WZqemka9cjkTyMN5geId6e8U5WGFAn3cQ==",
+         "dev": true,
+         "requires": {
+            "first-chunk-stream": "^3.0.0",
+            "strip-bom-buf": "^2.0.0"
          }
       },
       "strip-eof": {
@@ -9269,6 +12593,59 @@
          "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
          "dev": true
       },
+      "tar": {
+         "version": "2.2.2",
+         "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+         "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+         "dev": true,
+         "optional": true,
+         "requires": {
+            "block-stream": "*",
+            "fstream": "^1.0.12",
+            "inherits": "2"
+         }
+      },
+      "tar-fs": {
+         "version": "1.16.3",
+         "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+         "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+         "dev": true,
+         "optional": true,
+         "requires": {
+            "chownr": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pump": "^1.0.0",
+            "tar-stream": "^1.1.2"
+         },
+         "dependencies": {
+            "pump": {
+               "version": "1.0.3",
+               "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+               "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+               "dev": true,
+               "optional": true,
+               "requires": {
+                  "end-of-stream": "^1.1.0",
+                  "once": "^1.3.1"
+               }
+            }
+         }
+      },
+      "tar-stream": {
+         "version": "1.6.2",
+         "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+         "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+         "dev": true,
+         "requires": {
+            "bl": "^1.0.0",
+            "buffer-alloc": "^1.2.0",
+            "end-of-stream": "^1.0.0",
+            "fs-constants": "^1.0.0",
+            "readable-stream": "^2.3.0",
+            "to-buffer": "^1.1.1",
+            "xtend": "^4.0.0"
+         }
+      },
       "temporary": {
          "version": "0.0.8",
          "resolved": "https://registry.npmjs.org/temporary/-/temporary-0.0.8.tgz",
@@ -9278,11 +12655,72 @@
             "package": ">= 1.0.0 < 1.2.0"
          }
       },
+      "term-size": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+         "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+         "dev": true,
+         "requires": {
+            "execa": "^0.7.0"
+         },
+         "dependencies": {
+            "cross-spawn": {
+               "version": "5.1.0",
+               "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+               "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+               "dev": true,
+               "requires": {
+                  "lru-cache": "^4.0.1",
+                  "shebang-command": "^1.2.0",
+                  "which": "^1.2.9"
+               }
+            },
+            "execa": {
+               "version": "0.7.0",
+               "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+               "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+               "dev": true,
+               "requires": {
+                  "cross-spawn": "^5.0.1",
+                  "get-stream": "^3.0.0",
+                  "is-stream": "^1.1.0",
+                  "npm-run-path": "^2.0.0",
+                  "p-finally": "^1.0.0",
+                  "signal-exit": "^3.0.0",
+                  "strip-eof": "^1.0.0"
+               }
+            },
+            "get-stream": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+               "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+               "dev": true
+            }
+         }
+      },
       "text-table": {
          "version": "0.2.0",
          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
          "dev": true
+      },
+      "thenify": {
+         "version": "3.3.0",
+         "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+         "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+         "dev": true,
+         "requires": {
+            "any-promise": "^1.0.0"
+         }
+      },
+      "thenify-all": {
+         "version": "1.6.0",
+         "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+         "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+         "dev": true,
+         "requires": {
+            "thenify": ">= 3.1.0 < 4"
+         }
       },
       "throttleit": {
          "version": "1.0.0",
@@ -9324,6 +12762,12 @@
             "os-tmpdir": "~1.0.2"
          }
       },
+      "to-buffer": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+         "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+         "dev": true
+      },
       "to-fast-properties": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -9350,6 +12794,12 @@
             }
          }
       },
+      "to-readable-stream": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+         "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+         "dev": true
+      },
       "to-regex": {
          "version": "3.0.2",
          "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
@@ -9371,6 +12821,12 @@
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
          }
+      },
+      "tosource": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/tosource/-/tosource-1.0.0.tgz",
+         "integrity": "sha1-QtiN0RZhi88A1hBt1URvNCeQL/E=",
+         "dev": true
       },
       "tough-cookie": {
          "version": "2.4.3",
@@ -9398,6 +12854,12 @@
          "requires": {
             "punycode": "^2.1.0"
          }
+      },
+      "traverse": {
+         "version": "0.4.6",
+         "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.4.6.tgz",
+         "integrity": "sha1-0EsigOTHkqWBVCnve4tgxkyczDQ=",
+         "dev": true
       },
       "trim": {
          "version": "0.0.1",
@@ -9454,6 +12916,12 @@
          "version": "0.14.5",
          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+         "dev": true
+      },
+      "type": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+         "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
          "dev": true
       },
       "type-check": {
@@ -9596,6 +13064,15 @@
          "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
          "dev": true
       },
+      "unique-string": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+         "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+         "dev": true,
+         "requires": {
+            "crypto-random-string": "^1.0.0"
+         }
+      },
       "unist-util-find-all-after": {
          "version": "1.0.4",
          "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.4.tgz",
@@ -9644,6 +13121,12 @@
             "unist-util-is": "^3.0.0"
          }
       },
+      "universalify": {
+         "version": "0.1.2",
+         "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+         "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+         "dev": true
+      },
       "unset-value": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -9690,6 +13173,34 @@
          "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
          "dev": true
       },
+      "update-notifier": {
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
+         "integrity": "sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==",
+         "dev": true,
+         "requires": {
+            "boxen": "^3.0.0",
+            "chalk": "^2.0.1",
+            "configstore": "^4.0.0",
+            "has-yarn": "^2.1.0",
+            "import-lazy": "^2.1.0",
+            "is-ci": "^2.0.0",
+            "is-installed-globally": "^0.1.0",
+            "is-npm": "^3.0.0",
+            "is-yarn-global": "^0.3.0",
+            "latest-version": "^5.0.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+         },
+         "dependencies": {
+            "import-lazy": {
+               "version": "2.1.0",
+               "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+               "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+               "dev": true
+            }
+         }
+      },
       "uri-js": {
          "version": "4.2.2",
          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -9723,11 +13234,29 @@
             }
          }
       },
+      "url-parse-lax": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+         "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+         "dev": true,
+         "requires": {
+            "prepend-http": "^2.0.0"
+         }
+      },
       "use": {
          "version": "3.1.1",
          "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
          "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
          "dev": true
+      },
+      "user-home": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+         "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+         "dev": true,
+         "requires": {
+            "os-homedir": "^1.0.0"
+         }
       },
       "util": {
          "version": "0.10.4",
@@ -9751,6 +13280,16 @@
          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
          "dev": true
+      },
+      "util.promisify": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+         "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+         "dev": true,
+         "requires": {
+            "define-properties": "^1.1.2",
+            "object.getownpropertydescriptors": "^2.0.3"
+         }
       },
       "uuid": {
          "version": "3.3.2",
@@ -9849,6 +13388,12 @@
             "xml-name-validator": "^3.0.0"
          }
       },
+      "walkdir": {
+         "version": "0.0.11",
+         "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+         "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
+         "dev": true
+      },
       "watchify": {
          "version": "3.11.1",
          "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.11.1.tgz",
@@ -9862,6 +13407,218 @@
             "outpipe": "^1.1.0",
             "through2": "^2.0.0",
             "xtend": "^4.0.0"
+         }
+      },
+      "watchpack": {
+         "version": "1.6.0",
+         "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+         "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+         "dev": true,
+         "requires": {
+            "chokidar": "^2.0.2",
+            "graceful-fs": "^4.1.2",
+            "neo-async": "^2.5.0"
+         }
+      },
+      "wcwidth": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+         "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+         "dev": true,
+         "requires": {
+            "defaults": "^1.0.3"
+         }
+      },
+      "web-ext": {
+         "version": "3.2.0",
+         "resolved": "https://registry.npmjs.org/web-ext/-/web-ext-3.2.0.tgz",
+         "integrity": "sha512-UM2ucXzEKs6tD+YT6FjmfIeQtLy4t9CwdwyQl8Nthn2BbGgDLht+wBWsU8VYnNXtrObxX24Co8oaF7Id06JbgA==",
+         "dev": true,
+         "requires": {
+            "@babel/polyfill": "7.6.0",
+            "@babel/runtime": "7.6.2",
+            "@cliqz-oss/firefox-client": "0.3.1",
+            "@cliqz-oss/node-firefox-connect": "1.2.1",
+            "adbkit": "2.11.1",
+            "addons-linter": "1.14.0",
+            "bunyan": "1.8.12",
+            "camelcase": "5.3.1",
+            "chrome-launcher": "0.11.2",
+            "debounce": "1.2.0",
+            "decamelize": "3.2.0",
+            "es6-error": "4.1.1",
+            "event-to-promise": "0.8.0",
+            "firefox-profile": "1.2.0",
+            "fx-runner": "1.0.11",
+            "git-rev-sync": "1.12.0",
+            "import-fresh": "3.1.0",
+            "mkdirp": "0.5.1",
+            "multimatch": "4.0.0",
+            "mz": "2.7.0",
+            "node-notifier": "6.0.0",
+            "open": "6.4.0",
+            "parse-json": "5.0.0",
+            "sign-addon": "0.3.1",
+            "source-map-support": "0.5.13",
+            "stream-to-promise": "2.2.0",
+            "strip-bom": "4.0.0",
+            "strip-json-comments": "3.0.1",
+            "tmp": "0.1.0",
+            "update-notifier": "3.0.1",
+            "watchpack": "1.6.0",
+            "ws": "7.1.2",
+            "yargs": "13.3.0",
+            "zip-dir": "1.0.2"
+         },
+         "dependencies": {
+            "@babel/polyfill": {
+               "version": "7.6.0",
+               "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.6.0.tgz",
+               "integrity": "sha512-q5BZJI0n/B10VaQQvln1IlDK3BTBJFbADx7tv+oXDPIDZuTo37H5Adb9jhlXm/fEN4Y7/64qD9mnrJJG7rmaTw==",
+               "dev": true,
+               "requires": {
+                  "core-js": "^2.6.5",
+                  "regenerator-runtime": "^0.13.2"
+               }
+            },
+            "camelcase": {
+               "version": "5.3.1",
+               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+               "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+               "dev": true
+            },
+            "cliui": {
+               "version": "5.0.0",
+               "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+               "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+               "dev": true,
+               "requires": {
+                  "string-width": "^3.1.0",
+                  "strip-ansi": "^5.2.0",
+                  "wrap-ansi": "^5.1.0"
+               }
+            },
+            "decamelize": {
+               "version": "3.2.0",
+               "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-3.2.0.tgz",
+               "integrity": "sha512-4TgkVUsmmu7oCSyGBm5FvfMoACuoh9EOidm7V5/J2X2djAwwt57qb3F2KMP2ITqODTCSwb+YRV+0Zqrv18k/hw==",
+               "dev": true,
+               "requires": {
+                  "xregexp": "^4.2.4"
+               }
+            },
+            "emoji-regex": {
+               "version": "7.0.3",
+               "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+               "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+               "dev": true
+            },
+            "is-fullwidth-code-point": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+               "dev": true
+            },
+            "parse-json": {
+               "version": "5.0.0",
+               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+               "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+               "dev": true,
+               "requires": {
+                  "@babel/code-frame": "^7.0.0",
+                  "error-ex": "^1.3.1",
+                  "json-parse-better-errors": "^1.0.1",
+                  "lines-and-columns": "^1.1.6"
+               }
+            },
+            "string-width": {
+               "version": "3.1.0",
+               "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+               "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+               "dev": true,
+               "requires": {
+                  "emoji-regex": "^7.0.1",
+                  "is-fullwidth-code-point": "^2.0.0",
+                  "strip-ansi": "^5.1.0"
+               }
+            },
+            "strip-ansi": {
+               "version": "5.2.0",
+               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+               "dev": true,
+               "requires": {
+                  "ansi-regex": "^4.1.0"
+               }
+            },
+            "strip-bom": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+               "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+               "dev": true
+            },
+            "strip-json-comments": {
+               "version": "3.0.1",
+               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+               "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+               "dev": true
+            },
+            "tmp": {
+               "version": "0.1.0",
+               "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+               "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+               "dev": true,
+               "requires": {
+                  "rimraf": "^2.6.3"
+               }
+            },
+            "wrap-ansi": {
+               "version": "5.1.0",
+               "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+               "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+               "dev": true,
+               "requires": {
+                  "ansi-styles": "^3.2.0",
+                  "string-width": "^3.0.0",
+                  "strip-ansi": "^5.0.0"
+               }
+            },
+            "yargs": {
+               "version": "13.3.0",
+               "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+               "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+               "dev": true,
+               "requires": {
+                  "cliui": "^5.0.0",
+                  "find-up": "^3.0.0",
+                  "get-caller-file": "^2.0.1",
+                  "require-directory": "^2.1.1",
+                  "require-main-filename": "^2.0.0",
+                  "set-blocking": "^2.0.0",
+                  "string-width": "^3.0.0",
+                  "which-module": "^2.0.0",
+                  "y18n": "^4.0.0",
+                  "yargs-parser": "^13.1.1"
+               }
+            },
+            "yargs-parser": {
+               "version": "13.1.1",
+               "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+               "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+               "dev": true,
+               "requires": {
+                  "camelcase": "^5.0.0",
+                  "decamelize": "^1.2.0"
+               },
+               "dependencies": {
+                  "decamelize": {
+                     "version": "1.2.0",
+                     "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                     "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                     "dev": true
+                  }
+               }
+            }
          }
       },
       "webidl-conversions": {
@@ -9896,6 +13653,12 @@
             "webidl-conversions": "^4.0.2"
          }
       },
+      "when": {
+         "version": "3.7.7",
+         "resolved": "https://registry.npmjs.org/when/-/when-3.7.7.tgz",
+         "integrity": "sha1-q6A/w7tzbWyIsJHQE9io5ZDYRxg=",
+         "dev": true
+      },
       "which": {
          "version": "1.3.1",
          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -9910,6 +13673,13 @@
          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
          "dev": true
+      },
+      "which-pm-runs": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+         "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+         "dev": true,
+         "optional": true
       },
       "wide-align": {
          "version": "1.1.3",
@@ -9937,6 +13707,39 @@
                }
             }
          }
+      },
+      "widest-line": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+         "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+         "dev": true,
+         "requires": {
+            "string-width": "^2.1.1"
+         },
+         "dependencies": {
+            "is-fullwidth-code-point": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+               "dev": true
+            },
+            "string-width": {
+               "version": "2.1.1",
+               "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+               "dev": true,
+               "requires": {
+                  "is-fullwidth-code-point": "^2.0.0",
+                  "strip-ansi": "^4.0.0"
+               }
+            }
+         }
+      },
+      "winreg": {
+         "version": "0.0.12",
+         "resolved": "https://registry.npmjs.org/winreg/-/winreg-0.0.12.tgz",
+         "integrity": "sha1-BxBVVLoanQiXklHRKUdb/64wBrc=",
+         "dev": true
       },
       "wordwrap": {
          "version": "1.0.0",
@@ -10006,6 +13809,17 @@
             "mkdirp": "^0.5.1"
          }
       },
+      "write-file-atomic": {
+         "version": "2.4.3",
+         "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+         "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+         "dev": true,
+         "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+         }
+      },
       "ws": {
          "version": "7.1.2",
          "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz",
@@ -10021,10 +13835,33 @@
          "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
          "dev": true
       },
+      "xdg-basedir": {
+         "version": "3.0.0",
+         "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+         "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+         "dev": true
+      },
       "xml-name-validator": {
          "version": "3.0.0",
          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
          "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+         "dev": true
+      },
+      "xml2js": {
+         "version": "0.4.22",
+         "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.22.tgz",
+         "integrity": "sha512-MWTbxAQqclRSTnehWWe5nMKzI3VmJ8ltiJEco8akcC6j3miOhjjfzKum5sId+CWhfxdOs/1xauYr8/ZDBtQiRw==",
+         "dev": true,
+         "requires": {
+            "sax": ">=0.6.0",
+            "util.promisify": "~1.0.0",
+            "xmlbuilder": "~11.0.0"
+         }
+      },
+      "xmlbuilder": {
+         "version": "11.0.1",
+         "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+         "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
          "dev": true
       },
       "xmlchars": {
@@ -10038,6 +13875,15 @@
          "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.1.tgz",
          "integrity": "sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA==",
          "dev": true
+      },
+      "xregexp": {
+         "version": "4.2.4",
+         "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.2.4.tgz",
+         "integrity": "sha512-sO0bYdYeJAJBcJA8g7MJJX7UrOZIfJPd8U2SC7B2Dd/J24U0aQNoGp33shCaBSWeb0rD5rh6VBUIXOkGal1TZA==",
+         "dev": true,
+         "requires": {
+            "@babel/runtime-corejs2": "^7.2.0"
+         }
       },
       "xtend": {
          "version": "4.0.2",
@@ -10212,6 +14058,28 @@
          "dev": true,
          "requires": {
             "fd-slicer": "~1.0.1"
+         }
+      },
+      "zip-dir": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/zip-dir/-/zip-dir-1.0.2.tgz",
+         "integrity": "sha1-JT+QeurWKiGs2HIdi4gDKyQRwFE=",
+         "dev": true,
+         "requires": {
+            "async": "^1.5.2",
+            "jszip": "^2.4.0"
+         }
+      },
+      "zip-stream": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+         "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+         "dev": true,
+         "requires": {
+            "archiver-utils": "^1.3.0",
+            "compress-commons": "^1.2.0",
+            "lodash": "^4.8.0",
+            "readable-stream": "^2.0.0"
          }
       }
    }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,18 @@
 {
    "name": "WhoWroteThat",
-   "description": "A browser extension of WhoColor for Wikipedia",
+   "description": "Explore authorship and revision information visually and directly in Wikipedia articles. Powered by WikiWho.",
    "repository": "https://github.com/wikimedia/WhoWroteThat",
-   "version": "0.1.0",
+   "version": "0.2.0",
    "license": "MIT",
-   "scripts": {
-      "lint": "eslint .",
-      "test": "grunt test",
-      "mocha": "./node_modules/.bin/mocha --require @babel/register test/testHelper.js --recursive test/suite  --colors",
-      "build": "grunt build"
+   "webExt": {
+      "sourceDir": "dist/extension/",
+      "artifactsDir": "dist",
+      "build": {
+         "overwriteDest": true
+      },
+      "lint": {
+         "warningsAsErrors": false
+      }
    },
    "dependencies": {
       "@babel/polyfill": "^7.0.0"
@@ -28,6 +32,7 @@
       "grunt-banana-checker": "^0.7.1",
       "grunt-browserify": "^5.3.0",
       "grunt-contrib-clean": "^2.0.0",
+      "grunt-contrib-compress": "^1.5.0",
       "grunt-contrib-concat": "^1.0.1",
       "grunt-contrib-copy": "^1.0.0",
       "grunt-contrib-less": "^2.0.0",
@@ -35,13 +40,14 @@
       "grunt-eslint": "20.1.0",
       "grunt-jsdoc": "^2.4.0",
       "grunt-replace": "^1.0.1",
-      "grunt-run": "~0.8.1",
+      "grunt-shell": "^3.0.1",
       "grunt-stylelint": "^0.11.0",
+      "jquery": "~3.4.1",
       "jsdoc-wmf-theme": "^0.0.3",
       "jsdom": "~15.1.1",
       "mocha": "^6.2.0",
-      "jquery": "~3.4.1",
       "stylelint": "^10.1.0",
-      "stylelint-config-wikimedia": "0.6.0"
+      "stylelint-config-wikimedia": "0.6.0",
+      "web-ext": "^3.2.0"
    }
 }


### PR DESCRIPTION
Add new grunt tasks for linting and building the browser
extension. This builds the zip file (in dist/) that's
required for submitting to the Firefox Add-ons store.

This also switches from grunt-run to grunt-shell, to move
all of the build process into Gruntfile and out of
package.json.

The gecko extension ID is removed from the manifest.json
because an ID will be generated when the extension is signed,
and this part of that file has been raising a warning on
Chrome.

The web-ext lint Grunt task is not part of the normal lint
Grunt task because it only works after the extension is built
(whereas other linting is before build), and anyway we might
want to run (all other) linting on its own.

Bug: T232802