### PR TITLE
Clone original content later

### DIFF
--- a/src/ActivationSingleton.js
+++ b/src/ActivationSingleton.js
@@ -60,7 +60,6 @@ class ActivationSingleton {
 	 */
 	setProperties( $content, config ) {
 		this.$contentWrapper = $content;
-		this.$originalContent = this.$contentWrapper.clone();
 		this.lang = config.lang || 'en';
 		this.namespace = config.namespace || '';
 		this.mainPage = !!config.mainPage;
@@ -160,6 +159,15 @@ class ActivationSingleton {
 	 */
 	getContentWrapper() {
 		return this.$contentWrapper;
+	}
+
+	/**
+	 * Set the original content.
+	 *
+	 * @param {jQuery} $originalContent
+	 */
+	setOriginalContent( $originalContent ) {
+		this.$originalContent = $originalContent.clone( true, true );
 	}
 
 	/**

--- a/src/App.js
+++ b/src/App.js
@@ -91,7 +91,9 @@ class App {
 						return;
 					}
 					// Insert modified HTML.
-					$( '.mw-parser-output' ).html( this.api.getReplacementHtml() );
+					const $contentWrapper = activationInstance.getContentWrapper();
+					activationInstance.setOriginalContent( $contentWrapper );
+					$contentWrapper.html( this.api.getReplacementHtml() );
 					$( 'body' ).append( this.revisionPopup.$element );
 					this.attachContentListeners();
 					this.widget.setState( 'ready' );

--- a/test/suite/ActivationSingleton.test.js
+++ b/test/suite/ActivationSingleton.test.js
@@ -16,6 +16,7 @@ describe( 'ActivationSingleton test', () => {
 				mainPage: false
 			}
 		);
+		activationInstance.setOriginalContent( $someContent );
 
 		// Change the content
 		$someContent.empty().append(


### PR DESCRIPTION
Add a setter to ActivationSingleton so the $originalContent can
be stored when WWT is opened, so other gadgets etc. have already
modified the content.

Bug: T231424