### PR TITLE
BiDi and reinforcement: Add BiDi helper for usernames and content lang

### DIFF
--- a/src/Tools.js
+++ b/src/Tools.js
@@ -1,0 +1,36 @@
+const $ = require( 'jquery' );
+
+/**
+ * Class to hold some global helper tools
+ */
+class Tools {
+	/**
+	 * Encompass strings with BiDi isolation for RTL/LTR support.
+	 * This should be used on any string that is content language,
+	 * to make sure that if the user uses a different directionality
+	 * in the interface language, the output is shown properly
+	 * within a bidi isolation block.
+	 *
+	 * @param {jQuery|string} $content Content to isolate
+	 * @param {boolean} returnRawHtml Force the return value to
+	 *  be raw html. If set to false, will return the encompassed
+	 *  jQuery object.
+	 * @return {jQuery|string} BiDi isolated jQuery object or HTML
+	 */
+	static bidiIsolate( $content, returnRawHtml ) {
+		const $result = $( '<bdi>' );
+		if ( typeof $content === 'string' ) {
+			$result.text( $content );
+		} else {
+			$result.append( $content );
+		}
+
+		if ( returnRawHtml ) {
+			// `html()` sends the inner HTML, so we wrap the node
+			// and send the result to include the new <bdi> wrap
+			return $( '<div>' ).append( $result ).html();
+		}
+		return $result;
+	}
+}
+export default Tools;

--- a/test/suite/Tools.test.js
+++ b/test/suite/Tools.test.js
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+import Tools from '../../src/Tools';
+const $ = require( 'jquery' );
+
+describe( 'Tools test', () => {
+	describe( 'Tools.bidiIsolate', () => {
+		const cases = [
+			{
+				input: 'foo',
+				raw: true,
+				expected: '<bdi>foo</bdi>',
+				msg: 'Simple string'
+			},
+			{
+				input: 'foo with some spaces',
+				raw: true,
+				expected: '<bdi>foo with some spaces</bdi>',
+				msg: 'String with spaces'
+			},
+			{
+				input: '<a href="http://example.com/something?action=bar">a wrapped link</a>',
+				raw: true,
+				expected: '<bdi>&lt;a href="http://example.com/something?action=bar"&gt;a wrapped link&lt;/a&gt;</bdi>',
+				msg: 'Raw string gets escaped'
+			},
+			{
+				input: $( '<a>' )
+					.prop( 'href', 'http://example.com' )
+					.text( 'foo bar baz' ),
+				raw: true,
+				expected: '<bdi><a href="http://example.com">foo bar baz</a></bdi>',
+				msg: 'jQuery element'
+			}
+		];
+
+		cases.forEach( testCase => {
+			it( testCase.msg, () => {
+				expect( Tools.bidiIsolate( testCase.input, testCase.raw ) )
+					.to.equal( testCase.expected );
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
Any content that appears in the popup that comes from the content language
should be bidirectionally-isolated. This means that if our interface
language is Hebrew or any other RTL language, the usernames and/or
diff summaries should still render in the original content language
which may well be LTR.

This patch does a couple of cleanups and fortifications for the
rendering of html pieces:
- Adds a Tools class with 'bidi' helper and tests. This can be then
  used in other places in the system where we display usernames.
- Security:
  - Make sure anything served to the bidi isolation is fortified
    and escaped, or otherwise a raw string.
  - Make sure all _blank links have rel=noopener
  - Use templates for all except links, so we can make sure that
    link attributes are escaped.