### PR TITLE
Fix highlighting cutting off font kerning

### DIFF
--- a/src/less/general.less
+++ b/src/less/general.less
@@ -20,9 +20,20 @@ html.wwt-popup body {
 
 .mw-parser-output .editor-token {
 	cursor: pointer;
+	position: relative;
+	display: inline-block;
+	white-space: pre;
 
-	&.active {
+	&.active::before {
+		content: '';
 		background-color: #facc48;
+		position: absolute;
+		top: 0;
+		left: 0;
+		z-index: -1;
+		width: 100%;
+		height: 100%;
+		padding-bottom: 6px;
 	}
 }
 

--- a/src/less/general.less
+++ b/src/less/general.less
@@ -20,20 +20,10 @@ html.wwt-popup body {
 
 .mw-parser-output .editor-token {
 	cursor: pointer;
-	position: relative;
-	display: inline-block;
-	white-space: pre;
+	font-kerning: none;
 
-	&.active::before {
-		content: '';
+	&.active {
 		background-color: #facc48;
-		position: absolute;
-		top: 0;
-		left: 0;
-		z-index: -1;
-		width: 100%;
-		height: 100%;
-		padding-bottom: 6px;
 	}
 }
 


### PR DESCRIPTION
Add a ::before pseudo element to the 'active' CSS class, which is used to highlight when hovering
or selecting an element. When the .active class is set, a pseudo element is added behind it with
a background color that highlights the text. This behind-element approach will prevent any content
from being obscured.

Bug: T232490