### PR TITLE
Support hidden usernames

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -17,5 +17,6 @@
 	"ext-whowrotethat-tour-welcome-description": "Activate the the tool from the sidebar. Hover over the text to see the author and their other contributions to this page. Click to get more details.",
 	"ext-whowrotethat-tour-welcome-dismiss": "Got it!",
 	"ext-whowrotethat-revision-added": "$1 added this on $2.",
-	"ext-whowrotethat-revision-attribution": "They have written <strong>$1%</strong> of the page."
+	"ext-whowrotethat-revision-attribution": "They have written <strong>$1%</strong> of the page.",
+	"ext-whowrotethat-revision-deleted-username": "(username or IP removed)"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -17,5 +17,6 @@
 	"ext-whowrotethat-tour-welcome-description": "The description for the welcome popup that appears when the extension is enabled for the first time, explaining the activation and base usage of the extension.",
 	"ext-whowrotethat-tour-welcome-dismiss": "Button to permanently dismiss the welcome popup that appears when the extension is enabled for the first time.",
 	"ext-whowrotethat-revision-added": "Message shown in a popup that indicates who authored the text of an article. $1 is the username along with (talk | contribs) links, and $2 is a link to the diff with the timestamp as the link text.",
-	"ext-whowrotethat-revision-attribution": "Message indicating how much of the page an editor authored. This is shown immediately after the {{wm-msg|ext-whowrotethat-revision-added}} message."
+	"ext-whowrotethat-revision-attribution": "Message indicating how much of the page an editor authored. This is shown immediately after the {{wm-msg|ext-whowrotethat-revision-added}} message.",
+	"ext-whowrotethat-revision-deleted-username": "Message shown instead of the username if the username has been removed from public view."
 }


### PR DESCRIPTION
Show "(username or IP removed)" when the username has been hidden from
public view. We don't use the 'rev-deleted-user' message because, at
least on English Wikipedia, it uses parser functions and magic words
that aren't available in this context.

Highlighting tokens where the contributor username is hidden is still
not supported, but this can be addressed in a separate PR.

Bug: T232215