### PR TITLE
Display a verbal message if percentage is less than 1%

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,5 +18,6 @@
 	"ext-whowrotethat-tour-welcome-dismiss": "Got it!",
 	"ext-whowrotethat-revision-added": "$1 added this on $2.",
 	"ext-whowrotethat-revision-attribution": "They have written <strong>$1%</strong> of the page.",
+	"ext-whowrotethat-revision-attribution-lessthan": "They have written <strong>less than 1%</strong> of the page.",
 	"ext-whowrotethat-revision-deleted-username": "(username or IP removed)"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -17,6 +17,7 @@
 	"ext-whowrotethat-tour-welcome-description": "The description for the welcome popup that appears when the extension is enabled for the first time, explaining the activation and base usage of the extension.",
 	"ext-whowrotethat-tour-welcome-dismiss": "Button to permanently dismiss the welcome popup that appears when the extension is enabled for the first time.",
 	"ext-whowrotethat-revision-added": "Message shown in a popup that indicates who authored the text of an article. $1 is the username along with (talk | contribs) links, and $2 is a link to the diff with the timestamp as the link text.",
-	"ext-whowrotethat-revision-attribution": "Message indicating how much of the page an editor authored. This is shown immediately after the {{wm-msg|ext-whowrotethat-revision-added}} message.",
+	"ext-whowrotethat-revision-attribution": "Message indicating how much of the page an editor authored. This is shown immediately after the {{wm-msg|ext-whowrotethat-revision-added}} message.\n\nParameters: * $1: The percentage that represent how much of the page the editor authored.",
+	"ext-whowrotethat-revision-attribution-lessthan": "Message indicating that the author has edited less than 1% of the page. This is shown immediately after the {{wm-msg|ext-whowrotethat-revision-added}} message.",
 	"ext-whowrotethat-revision-deleted-username": "Message shown instead of the username if the username has been removed from public view."
 }

--- a/src/RevisionPopupWidget.js
+++ b/src/RevisionPopupWidget.js
@@ -124,7 +124,8 @@ RevisionPopupWidget.prototype.show = function ( data, $target ) {
 			.attr( 'href', mw.util.getUrl( `Special:Diff/${data.revisionId}` ) )
 			.text( dateStr ),
 		addedMsg = mw.message( 'ext-whowrotethat-revision-added', $userLinks, $diffLink ).parse(),
-		attributionMsg = `<div class="ext-wwt-revisionPopupWidget-attribution">${mw.message( 'ext-whowrotethat-revision-attribution', data.score ).parse()}</div>`,
+		scoreMsgKey = Number( data.score ) >= 1 ? 'ext-whowrotethat-revision-attribution' : 'ext-whowrotethat-revision-attribution-lessthan',
+		attributionMsg = `<div class="ext-wwt-revisionPopupWidget-attribution">${mw.message( scoreMsgKey, data.score ).parse()}</div>`,
 		html = $.parseHTML( `
 			${addedMsg.trim()}
 			${getCommentHtml( data )}


### PR DESCRIPTION
In the revision popup, if an editor has a percentage that is less
than 1%, do not display the fraction, but instead display a literal
message saying 'less than 1%'.

Bonus for this PR: Add parameter documentation to qqq.json for the
original message.

Bug: https://phabricator.wikimedia.org/T233164