### PR TITLE
Always use correct revision ID

### DIFF
--- a/src/Controller.js
+++ b/src/Controller.js
@@ -91,7 +91,8 @@ class Controller {
 		if ( window.mw ) {
 			this.api = new Api( {
 				url: config.wikiWhoUrl,
-				mwApi: new mw.Api()
+				mwApi: new mw.Api(),
+				mwConfig: mw.config
 			} );
 			this.api.fetchMessages();
 

--- a/test/suite/Api.test.js
+++ b/test/suite/Api.test.js
@@ -2,52 +2,51 @@ import { expect } from 'chai';
 import Api from '../../src/Api';
 
 describe( 'Api test', () => {
-	describe( 'getQueryParameter', () => {
-		it( 'Should get a simple parameter', () => {
-			const a = new Api();
-			expect( a.getQueryParameter( '?foo=bar', 'foo' ) ).to.equal( 'bar' );
-		} );
-
-		it( 'Should get a simple parameter among some', () => {
-			const a = new Api();
-			expect( a.getQueryParameter( '?foo=bar&baz=quuz', 'baz' ) ).to.equal( 'quuz' );
-		} );
-	} );
 
 	describe( 'getAjaxURL', () => {
 		const cases = [
 			{
 				msg: 'Should get the correct API URL',
-				input: 'https://en.wikipedia.org/wiki/Foo',
-				expected: 'https://wikiwho.example.com/en/whocolor/v1.0.0-beta/Foo/'
-			},
-			{
-				msg: 'Should get the correct API URL without fragment',
-				input: 'https://en.wikipedia.org/wiki/Foo#section',
-				expected: 'https://wikiwho.example.com/en/whocolor/v1.0.0-beta/Foo/'
-			},
-			{
-				msg: 'Should get the correct API URL without query string',
-				input: 'https://en.wikipedia.org/wiki/Iñtërnâtiônàlizætiøn_(disambig)?debug=1',
+				config: {
+					wgServerName: 'en.wikipedia.org',
+					wgPageName: 'Iñtërnâtiônàlizætiøn_(disambig)'
+				},
 				expected: 'https://wikiwho.example.com/en/whocolor/v1.0.0-beta/Iñtërnâtiônàlizætiøn_(disambig)/'
 			},
 			{
-				msg: 'Should get the correct API URL from title parameter',
-				input: 'https://en.wikipedia.org/w/index.php?title=Foo',
-				expected: 'https://wikiwho.example.com/en/whocolor/v1.0.0-beta/Foo/'
+				msg: 'Should only append a revision ID if it is not the current one',
+				config: {
+					wgServerName: 'cbk-zam.wikipedia.org',
+					wgPageName: 'Foo',
+					wgRevisionId: 123,
+					wgCurRevisionId: 123
+				},
+				expected: 'https://wikiwho.example.com/cbk-zam/whocolor/v1.0.0-beta/Foo/'
 			},
 			{
-				msg: 'Should get the correct API URL with oldid parameter',
-				input: 'https://ru.wikipedia.org/w/index.php?title=Foo&oldid=123',
+				msg: 'Should get the correct API URL with an old revision ID',
+				config: {
+					wgServerName: 'ru.wikipedia.org',
+					wgPageName: 'Foo',
+					wgRevisionId: 123,
+					wgCurRevisionId: 456
+				},
 				expected: 'https://wikiwho.example.com/ru/whocolor/v1.0.0-beta/Foo/123/'
 			}
 		];
 
 		// Run all test cases
 		cases.forEach( testCase => {
-			const a = new Api( { url: 'https://wikiwho.example.com/' } );
+			// Dummy version of mw.Map to use as config.
+			const config = {
+					data: testCase.config,
+					get: function ( key ) {
+						return this.data[ key ];
+					}
+				},
+				a = new Api( { url: 'https://wikiwho.example.com/', mwConfig: config } );
 			it( testCase.msg, () => {
-				expect( a.getAjaxURL( testCase.input ) ).to.equal( testCase.expected );
+				expect( a.getAjaxURL() ).to.equal( testCase.expected );
 			} );
 		} );
 	} );


### PR DESCRIPTION
Get rid of URL parsing and instead use mw.config values. This not
only gets us away from parsing the URL manually but more
importantly means the revision ID will always be correct (we were
just using the 'oldid' URL parameter, which is incorrect when
there is also a 'direction' URL parameter).

https://phabricator.wikimedia.org/T232059

Bug: T232059