### PR TITLE
Enable/disable based on whether VisualEditor is opened

### DIFF
--- a/src/Controller.js
+++ b/src/Controller.js
@@ -114,6 +114,18 @@ class Controller {
 				mw.msg( 'whowrotethat-activation-link-tooltip' )
 			);
 
+			// Add hooks for VisualEditor
+			mw.hook( 've.activationComplete' ).add( () => {
+				window.console.log( 'Who Wrote That: VisualEditor activated, disabling system.' );
+
+				this.dismiss();
+				this.model.toggleEnabled( false );
+			} );
+			mw.hook( 've.deactivationComplete' ).add( () => {
+				window.console.log( 'Who Wrote That: VisualEditor deactivated, enabling system.' );
+				this.model.toggleEnabled( true );
+			} );
+
 			this.initialized = true;
 		}
 	}


### PR DESCRIPTION
When VisualEditor is opened, automatically dismiss WWT and disable
the link. When VisualEditor is closed, re-enable the WWT link.

Bug: https://phabricator.wikimedia.org/T231508

We will handle post-save in VisualEditor in a followup patch (related bug for followup: https://phabricator.wikimedia.org/T235015)