### PR TITLE
Remove jQuery from bundled script

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -97,21 +97,24 @@ module.exports = function Gruntfile( grunt ) {
 				src: 'src/outputs/gadget.js',
 				dest: 'dist/gadget/generated.whowrotethat.js',
 				options: {
-					transform: [ 'babelify' ]
+					transform: [ 'babelify' ],
+					exclude: [ 'jquery' ]
 				}
 			},
 			browserextension: {
 				src: 'src/outputs/browserextension.js',
 				dest: 'dist/extension/js/generated.pageScript.js',
 				options: {
-					transform: [ 'babelify' ]
+					transform: [ 'babelify' ],
+					exclude: [ 'jquery' ]
 				}
 			},
 			browserextensionTour: {
 				src: 'src/outputs/browserextension_tour.js',
 				dest: 'dist/extension/js/generated.welcomeTour.js',
 				options: {
-					transform: [ 'babelify' ]
+					transform: [ 'babelify' ],
+					exclude: [ 'jquery' ]
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
          "overwriteDest": true
       },
       "lint": {
-         "warningsAsErrors": false
+         "warningsAsErrors": true
       }
    },
    "dependencies": {

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -1,6 +1,7 @@
 import Api from './Api';
 import Model from './Model';
-const $ = require( 'jquery' );
+const $ = window.$ || require( 'jquery' );
+
 /**
  * An activation singleton, responsible for activating and attaching the
  * button that activates the system when it is applicable.

--- a/src/Tools.js
+++ b/src/Tools.js
@@ -1,4 +1,4 @@
-const $ = require( 'jquery' );
+const $ = window.$ || require( 'jquery' );
 
 /**
  * Class to hold some global helper tools


### PR DESCRIPTION
We don't need to bundle jQuery module into the script because
we are injecting it into MW where jQuery already exists.

Remove jQuery from babelify operation, and make sure that the module
only loads if `$` isn't set, which is relevant for tests.