### PR TITLE
Cleanup: Drop jquery fallback, only use in tests

### DIFF
--- a/src/Controller.js
+++ b/src/Controller.js
@@ -1,6 +1,5 @@
 import Api from './Api';
 import Model from './Model';
-const $ = window.$ || require( 'jquery' );
 
 /**
  * An activation singleton, responsible for activating and attaching the

--- a/src/Tools.js
+++ b/src/Tools.js
@@ -1,5 +1,3 @@
-const $ = window.$ || require( 'jquery' );
-
 /**
  * Class to hold some global helper tools
  */

--- a/test/suite/Controller.test.js
+++ b/test/suite/Controller.test.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import wwtController from '../../src/Controller';
-const $ = require( 'jquery' );
 
 describe( 'wwtController test', () => {
 	const $someContent = $( '<div>' )

--- a/test/suite/Tools.test.js
+++ b/test/suite/Tools.test.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import Tools from '../../src/Tools';
-const $ = require( 'jquery' );
 
 describe( 'Tools test', () => {
 	describe( 'Tools.bidiIsolate', () => {

--- a/test/testHelper.js
+++ b/test/testHelper.js
@@ -10,6 +10,7 @@ function copyProps(src, target) {
 }
 
 global.window = window;
+global.$ = require( 'jquery' );
 global.document = window.document;
 global.navigator = {
 	userAgent: 'node.js',


### PR DESCRIPTION
The initial need for `const $ = ...` was for making sure that
tests have that package, while not polluting the general scripts
with an unnecessary overload of jquery that already exists in
mediawiki.

Instead of doing that, we can use the testHelper's mocking of the
globals to pretend `window.$` is set to jquery, which would mean
it's already available all the time.

Props to @samwilson on questioning the original approach.