### PR TITLE
Cache all promises and DOM elements

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -56,14 +56,13 @@ class Model extends EventEmitter {
 	/**
 	 * Cache the original content we are about to replace
 	 *
-	 * @param {jQuery} [$content=this.$contentWrapper] A jQuery
+	 * @param {jQuery} [$content=this.$contentWrapper.contents()] A jQuery
 	 *  object to cache. If not given the $contentWrapper will
 	 *  be cached. In most cases this should remain empty,
 	 *  as $contentWrapper contains the original content before
 	 *  it is replaced.
 	 */
-	cacheOriginal( $content = this.$contentWrapper ) {
-		$content = $content || this.$contentWrapper;
+	cacheOriginal( $content = this.$contentWrapper.contents() ) {
 		this.$originalContent = $content.clone( true, true );
 	}
 

--- a/src/less/general.less
+++ b/src/less/general.less
@@ -9,7 +9,7 @@ html.wwt-popup body {
 }
 
 // Disable all links in the content area, other than in-page (fragment) links.
-.mw-parser-output.wwt-active a {
+.mw-parser-output.wwt-ready a {
 	pointer-events: none;
 
 	// Re-enable those with a href that start with a hash/pound/octothorpe.

--- a/test/suite/Api.test.js
+++ b/test/suite/Api.test.js
@@ -9,19 +9,19 @@ describe( 'Api test', () => {
 				msg: 'Should get the correct API URL',
 				config: {
 					wgServerName: 'en.wikipedia.org',
+					wgRevisionId: 234,
 					wgPageName: 'Iñtërnâtiônàlizætiøn_(disambig)'
 				},
-				expected: 'https://wikiwho.example.com/en/whocolor/v1.0.0-beta/Iñtërnâtiônàlizætiøn_(disambig)/'
+				expected: 'https://wikiwho.example.com/en/whocolor/v1.0.0-beta/Iñtërnâtiônàlizætiøn_(disambig)/234/'
 			},
 			{
 				msg: 'Should only append a revision ID if it is not the current one',
 				config: {
 					wgServerName: 'cbk-zam.wikipedia.org',
 					wgPageName: 'Foo',
-					wgRevisionId: 123,
-					wgCurRevisionId: 123
+					wgRevisionId: 123
 				},
-				expected: 'https://wikiwho.example.com/cbk-zam/whocolor/v1.0.0-beta/Foo/'
+				expected: 'https://wikiwho.example.com/cbk-zam/whocolor/v1.0.0-beta/Foo/123/'
 			},
 			{
 				msg: 'Should get the correct API URL with an old revision ID',

--- a/test/suite/Model.test.js
+++ b/test/suite/Model.test.js
@@ -118,7 +118,9 @@ describe( 'Model test', () => {
 				.to.equal( '<a>A link instead</a>' );
 		} );
 		it( 'getOriginalContent returns original content', () => {
-			expect( m.getOriginalContent().html() )
+			expect(
+				m.getOriginalContent()[ 0 ].outerHTML
+			)
 				.to.equal( '<span>This is the original DOM structure</span>' );
 		} );
 


### PR DESCRIPTION
This cleanup makes sure we are always working with the current and correct data, and are intentionally adding events once to the DOM we are getting from the API, without having to redo the operation in case WWT is closed and reopened.

However, this also makes sure that if the revision has changed between close/reopen, we are then refetching the correct data and caching it.

Specifically in this commit:
* Cache the WhoColor API data based on the revisionID we are currently looking at; do not refetch unnecessarily, refetch when needed.
* Cache revision summary API requests based on revision ID. For followup, this will also allow us to control the animationn better and decide to animate only if the data has not yet been fetched.
* Always send revision ID to WhoColor API. We can make 100% sure that what we get from WhoColor is the specific revision we're looking at. This protects us from two main cases:
  1. Case where we look at the recent revision, but while we are looking at the article and before we asked WWT for info, someone else edited the same article. In the case before this commit, WhoColor would have sent us the latest revision which would have been different than what we are looking at.
  2. If a user edited the page in VisualEditor or the new wikitext editor, the page does not refresh. If we ask for WWT data, we want to make sure we're getting the correct new revision ID rather than an older one.
* Create a sanitized token info object on initialization. This means that we have the data available immediately to render on hover and click, rather than having to constantly look it up in the API results. Also, this allows us to make the API process more internally independent, where we only cache data that is needed rather than having a lot of the methods having to go back-and-forth with class variables that are set within the Promise.
* Have `App` class fully handle the DOM we receive from the API. By storing it properly, we make sure we always deal with a fully processed DOM without having to attach events over and over, unless the DOM element has explicitly changed because the revision ID we are looking at has changed. This also allows us to be much safer in what DOM we are returning back to the user on deactivation, and make sure we encapsulate the behavior so we can switch the elements back and forth safely.

This commit will make it possible, as followups, to:
* Control the 'loading' animation of the edit summaries; since they are now based on cached promises, it will be easier to only display the loading animation only if needed.
* On VisualEditor save, it is now possible to refetch WWT data, whether it exists or not in WhoColor.

Bug: https://phabricator.wikimedia.org/T234483