### PR TITLE
Separate Firefox and Chrome manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ There's a Grunt job to output the code into both a working browser extension and
 After updating the version number in `package.json`
 and tagging the release in Git,
 run `grunt` (the default task only) to create
-a zip file such as `dist/whowrotethat_for_wikipedia-0.2.0.0.zip`.
+a zip file such as `dist/extension_firefox/whowrotethat_for_wikipedia-0.2.0.0.zip`.
 This can be uploaded to the Firefox and Chrome browser stores.
 
 A second zip file is also produced, containing the source code.
-This is required for submission to the Firefox add-ons store.
+This is required for submission to the Firefox add-ons store (but not for Chrome).
 
 ## Debugging
 

--- a/build/extension_manifest.json
+++ b/build/extension_manifest.json
@@ -11,6 +11,11 @@
 		"128": "icons/icon-128.png",
 		"256": "icons/icon-128@2x.png"
 	},
+	"browser_specific_settings": {
+		"gecko": {
+			"id": "whowrotethat@wikimedia"
+		}
+	},
 	"content_scripts": [ {
 		"matches": [
 			"*://en.wikipedia.org/*",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
    "license": "MIT",
    "webExt": {
       "sourceDir": "dist/extension/",
-      "artifactsDir": "dist",
       "build": {
          "overwriteDest": true
       },


### PR DESCRIPTION
This adds the Gecko ID back into manifest.json, and creates a
new build process that uses separate manifest files for Chrome
and Firefox, outputting two zip files for upload to the web
stores.

We removed the Gecko ID because I thought it wasn't required and
it was causing a warning in Chrome. Turns out the storage.sync API
isn't available unless you set it.

https://phabricator.wikimedia.org/T236226
https://phabricator.wikimedia.org/T232460

Bug: T236226
Bug: T232460