### PR TITLE
Build different zip files for beta and prod

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3,7 +3,9 @@
 		"authors": []
 	},
 	"whowrotethat-ext-name": "Who Wrote That?",
+	"whowrotethat-ext-name-beta": "Who Wrote That? (BETA)",
 	"whowrotethat-ext-desc": "Explore authorship and revision information visually and directly in Wikipedia articles. Powered by WikiWho.",
+	"whowrotethat-ext-desc-beta": "This is the BETA version, intended for testing only and possibly containing bugs. If you find any issues, please report them on our Phabricator board.",
 	"whowrotethat-activation-link": "Who Wrote That?",
 	"whowrotethat-activation-link-tooltip": "Activate Who Wrote That?",
 	"whowrotethat-deactivation-link": "Close Who Wrote That?",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -6,7 +6,9 @@
 		]
 	},
 	"whowrotethat-ext-name": "The name of the browser extension (used on the Firefox and Chrome stores).",
+	"whowrotethat-ext-name-beta": "The name of the beta version of the browser extension (used on the Firefox and Chrome stores).",
 	"whowrotethat-ext-desc": "A description of the browser extension (used on the Firefox and Chrome stores).",
+	"whowrotethat-ext-desc-beta": "Text added to the description of the browser extension, after {{msg-mw|whowrotethat-ext-desc}} (used on the Firefox and Chrome stores).",
 	"whowrotethat-activation-link": "The text for the link that turns Who Wrote That on",
 	"whowrotethat-activation-link-tooltip": "The tooltip for the link that turns Who Wrote That on",
 	"whowrotethat-deactivation-link": "The text for the link that turns Who Wrote That off",


### PR DESCRIPTION
The name and description are different for prod and beta, so this
adds new i18n messages for these and dynamically adds them to the
web extensions' locales files. It also separates extension
building from the main build task (into a new 'webext' task).

Bug: T236226