### PR TITLE
Truncate overly long extension messages

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -193,32 +193,41 @@ module.exports = function Gruntfile( grunt ) {
 			langBlob = generateLangBlob(),
 			qqq = grunt.file.readJSON( 'i18n/qqq.json' );
 		Object.keys( langBlob ).forEach( function ( lang ) {
-			const locale = {},
-				nameMsg = isBeta ? 'whowrotethat-ext-name-beta' : 'whowrotethat-ext-name';
-			// Name (may be beta).
+			const localeFile = 'dist/extension/_locales/' + lang + '/messages.json',
+				betaLogMsg = isBeta ? 'beta ' : '',
+				nameMsg = isBeta ? 'whowrotethat-ext-name-beta' : 'whowrotethat-ext-name',
+				descMsg = isBeta ? 'whowrotethat-ext-desc-beta' : 'whowrotethat-ext-desc',
+				// The name and description messages default to English because Chrome doesn't do
+				// its own fallbacks.
+				locale = {
+					name: {
+						message: langBlob.en[ nameMsg ],
+						description: qqq[ nameMsg ]
+					},
+					description: {
+						message: langBlob.en[ descMsg ],
+						description: qqq[ descMsg ]
+					}
+				};
+			// Name (may be for beta). Maximum length 45 characters.
 			if ( langBlob[ lang ][ nameMsg ] ) {
-				locale.name = {
-					message: langBlob[ lang ][ nameMsg ],
-					description: qqq[ nameMsg ]
-				};
-			}
-			// Description (may have beta appended).
-			if ( langBlob[ lang ][ 'whowrotethat-ext-desc' ] ) {
-				let desc = langBlob[ lang ][ 'whowrotethat-ext-desc' ];
-				if ( isBeta && langBlob[ lang ][ 'whowrotethat-ext-desc-beta' ] ) {
-					desc += '\n\n' + langBlob[ lang ][ 'whowrotethat-ext-desc-beta' ];
+				const name = langBlob[ lang ][ nameMsg ];
+				if ( name.length >= 45 ) {
+					grunt.log.error( 'The ' + lang + " '" + nameMsg + "' message must be 45 characters or less. Provided: " + name );
 				}
-				locale.description = {
-					message: desc,
-					description: qqq[ 'whowrotethat-ext-desc' ]
-				};
+				locale.name.message = name.substring( 0, 44 );
 			}
-			if ( locale.name || locale.description ) {
-				const localeFile = 'dist/extension/_locales/' + lang + '/messages.json',
-					betaLogMsg = isBeta ? 'beta ' : '';
-				grunt.log.ok( 'Writing ' + betaLogMsg + 'messages to ' + localeFile );
-				grunt.file.write( localeFile, JSON.stringify( locale, null, 4 ) );
+			// Description (may have beta appended). Maximum 132 characters.
+			if ( langBlob[ lang ][ descMsg ] ) {
+				const desc = langBlob[ lang ][ descMsg ];
+				if ( desc.length >= 132 ) {
+					grunt.log.error( 'The ' + lang + " '" + nameMsg + "' message must be 132 characters or less. Provided: " + desc );
+				}
+				locale.description.message = desc.substring( 0, 131 );
 			}
+			// Write the locale file.
+			grunt.log.ok( 'Writing ' + betaLogMsg + 'messages to ' + localeFile );
+			grunt.file.write( localeFile, JSON.stringify( locale, null, 4 ) );
 		} );
 	} );
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5,7 +5,7 @@
 	"whowrotethat-ext-name": "Who Wrote That?",
 	"whowrotethat-ext-name-beta": "Who Wrote That? (BETA)",
 	"whowrotethat-ext-desc": "Explore authorship and revision information visually and directly in Wikipedia articles. Powered by WikiWho.",
-	"whowrotethat-ext-desc-beta": "This is the BETA version, intended for testing only and possibly containing bugs. If you find any issues, please report them on our Phabricator board.",
+	"whowrotethat-ext-desc-beta": "Explore Wikipedia authorship information. Powered by WikiWho. This is the BETA version, intended for testing only.",
 	"whowrotethat-activation-link": "Who Wrote That?",
 	"whowrotethat-activation-link-tooltip": "Activate Who Wrote That?",
 	"whowrotethat-deactivation-link": "Close Who Wrote That?",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -6,10 +6,10 @@
 			"Hamilton Abreu"
 		]
 	},
-	"whowrotethat-ext-name": "The name of the browser extension (used on the Firefox and Chrome stores).",
-	"whowrotethat-ext-name-beta": "The name of the beta version of the browser extension (used on the Firefox and Chrome stores).",
-	"whowrotethat-ext-desc": "A description of the browser extension (used on the Firefox and Chrome stores).",
-	"whowrotethat-ext-desc-beta": "Text added to the description of the browser extension, after {{msg-mw|whowrotethat-ext-desc}} (used on the Firefox and Chrome stores).",
+	"whowrotethat-ext-name": "The name of the browser extension (used on the Firefox and Chrome stores). Maximum 45 characters.",
+	"whowrotethat-ext-name-beta": "The name of the beta version of the browser extension (used on the Firefox and Chrome stores). Maximum 45 characters.",
+	"whowrotethat-ext-desc": "Description of the browser extension (used on the Firefox and Chrome stores). Maximum 132 characters.",
+	"whowrotethat-ext-desc-beta": "Description of the beta version of the browser extension (used on the Firefox and Chrome stores). Maximum 132 characters.",
 	"whowrotethat-activation-link": "The text for the link that turns Who Wrote That on",
 	"whowrotethat-activation-link-tooltip": "The tooltip for the link that turns Who Wrote That on",
 	"whowrotethat-deactivation-link": "The text for the link that turns Who Wrote That off",


### PR DESCRIPTION
Chrome has maximum length requirements for name and description.
This truncates these messages if they're too long, and outputs
an error during build. It does not fail the build.

Bug: T237756