### PR TITLE
Initialize the button with a correct initial state

### DIFF
--- a/src/Controller.js
+++ b/src/Controller.js
@@ -133,6 +133,8 @@ class Controller {
 				't-whowrotethat',
 				mw.msg( 'whowrotethat-activation-link-tooltip' )
 			);
+			// Initial state
+			this.getButton().toggle( this.model.isEnabled() );
 
 			// Add hooks for VisualEditor
 			mw.hook( 've.activationComplete' ).add( () => {


### PR DESCRIPTION
The button is initialized potentially out of sync of whether an
initializing event for changing the model state has fired; the
button state should initialize with whatever model state exists
and then change itself based on further events.

Bug: https://phabricator.wikimedia.org/T231508