### PR TITLE
Only show loading animation if comment isn't yet available

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -26,6 +26,20 @@ class Api {
 	}
 
 	/**
+	 * Check whether a revision ID promise is cached
+	 *
+	 * @param  {string} revId Revision ID
+	 * @param  {string} [type='summaries'] Promise data type
+	 *  'summaries' or 'data'
+	 * @return {boolean} The promise is cached
+	 */
+	isCached( revId, type = 'summaries' ) {
+		return !!(
+			this.promiseCache[ type ] &&
+			this.promiseCache[ type ][ revId ]
+		);
+	}
+	/**
 	 * Fetch core messages needed for the revision popup, etc., making them available to mw.msg().
 	 * This is called just after the script is first loaded, and the request completes very quickly,
 	 * so we shouldn't need to bother with promises and such.

--- a/src/App.js
+++ b/src/App.js
@@ -184,10 +184,12 @@ class App {
 			} )
 			.on( 'click', e => {
 				const ids = this.getIdsFromElement( e.currentTarget ),
-					tokenInfo = wwtController.getApi().getTokenInfo( ids.tokenId );
+					tokenInfo = wwtController.getApi().getTokenInfo( ids.tokenId ),
+					isCached = wwtController.getApi().isCached( tokenInfo.revisionId );
+
 				this.activateSpans( $content, ids.editorId );
 				this.widget.setUsernameInfo( tokenInfo.username );
-				this.revisionPopup.show( tokenInfo, $( e.currentTarget ) );
+				this.revisionPopup.show( tokenInfo, $( e.currentTarget ), isCached );
 				this.revisionPopup.once( 'toggle', () => {
 					this.deactivateSpans( $content );
 					this.widget.clearUsernameInfo();
@@ -195,11 +197,14 @@ class App {
 
 				// eslint-disable-next-line one-var
 				const reqStartTime = Date.now();
-
 				// Fetch edit summary then re-render the popup.
 				wwtController.getApi().fetchEditSummary( tokenInfo.revisionId )
 					.then( successData => {
-						const delayTime = Date.now() - reqStartTime < 250 ? 250 : 0;
+						const delayTime = (
+							!isCached &&
+							Date.now() - reqStartTime < 250
+						) ? 250 : 0;
+
 						Object.assign( tokenInfo, successData );
 
 						setTimeout( () => {

--- a/src/less/RevisionPopupWidget.less
+++ b/src/less/RevisionPopupWidget.less
@@ -18,12 +18,12 @@
 	margin-top: 8px;
 }
 
-.wwt-revisionPopupWidget-comment {
+.wwt-revisionPopupWidget-comment-animated {
 	transition: opacity 1s;
 	opacity: 1;
 }
 
-.wwt-revisionPopupWidget-comment-transparent {
+.wwt-revisionPopupWidget-comment-animated-transparent {
 	opacity: 0;
 }
 


### PR DESCRIPTION
We should be using a better approach in general where all
behavior is in a single place rather than passing state to
two, relying on the promise chain -- but changing this is
a bit more refactor-heavy, so this is a good fix until we
decide there's capacity to do a bit more of a refactoring
to take advantage of the cached promises directly.

Bug: https://phabricator.wikimedia.org/T234463