### PR TITLE
Fix percentage attribution score for IP contributors

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -178,10 +178,6 @@ class Api {
 		revision = results.revisions[ revId ];
 		username = revision[ 3 ];
 
-		// WikiWho prefixes IP addresses with '0|'.
-		isIP = username.slice( 0, 2 ) === '0|';
-		username = isIP ? username.slice( 2 ) : username;
-
 		// Get the user's edit score (percentage of content edited).
 		// results.present_editors structure:
 		// [ [ username, user_id, score ], ... ]
@@ -191,6 +187,12 @@ class Api {
 				break;
 			}
 		}
+
+		// WikiWho prefixes IP addresses with '0|'.
+		isIP = username.slice( 0, 2 ) === '0|';
+		// Clean up username if it is an IP for displaying after
+		// the user's score edit has been calculated
+		username = isIP ? username.slice( 2 ) : username;
 
 		// Put it all together.
 		return {


### PR DESCRIPTION
Fix user edit scores for IP contributors shown in details
pop-up. The score should match the data retrieved from WhoColor Api.

Bug: T235775