### PR TITLE
Use default Gecko ID, for build-only local running

### DIFF
--- a/build/extension_manifest.json
+++ b/build/extension_manifest.json
@@ -13,7 +13,7 @@
 	},
 	"browser_specific_settings": {
 		"gecko": {
-			"id": "[See the Grunt 'extManifests' task.]"
+			"id": "whowrotethat-dev@wikimedia"
 		}
 	},
 	"content_scripts": [ {


### PR DESCRIPTION
If we use a placeholder as the Gecko ID, and build a local
development version of the extension, Firefox complains that the
ID is not in the correct format. Instead of the placeholder, this
adds a conforming ID.