### PR TITLE
Prevent content script from being injected more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Build: Provide valid Gecko-ID for local development
+- Prevent the extension script from loading more than once on a Wikipedia page
 
 ### Changed
 - Translation updates

--- a/build/extension_content_script.js
+++ b/build/extension_content_script.js
@@ -10,18 +10,25 @@ function log( str ) {
 	window.console.info( 'Who Wrote That? (Browser extension): ' + str );
 }
 /**
- * injectScript - Inject internal script to available access to the `window`
+ * Inject the extension's content script to the DOM, so that it's got access to the `window` object.
  *
  * @param  {string} filePath Local path of the internal script.
  * @param  {string} tag The tag as string, where the script will be append (default: 'body').
  * @see    {@link http://stackoverflow.com/questions/20499994/access-window-variable-from-content-script}
  */
 function injectScript( filePath, tag ) {
-	var node = document.getElementsByTagName( tag )[ 0 ],
-		script = document.createElement( 'script' );
-
-	script.setAttribute( 'type', 'text/javascript' );
-	script.setAttribute( 'src', filePath );
+	const wwtScriptId = 'wwt-content-script',
+		existingScript = document.getElementById( wwtScriptId );
+	if ( existingScript ) {
+		// Already injected.
+		return;
+	}
+	// Otherwise, inject a new script element.
+	let script = document.createElement( 'script' ),
+		node = document.getElementsByTagName( tag )[ 0 ];
+	script.id = wwtScriptId;
+	script.type = 'text/javascript';
+	script.src = filePath;
 	node.appendChild( script );
 }
 
@@ -38,7 +45,7 @@ function activateWelcomeTour() {
 			return;
 		}
 
-		// Set a class on the HTML so the script knows taht the welcome tour
+		// Set a class on the HTML so the script knows that the welcome tour
 		// should load
 		document.getElementsByTagName( 'html' )[ 0 ]
 			.classList.add( 'wwt-welcome-tour-unseen' );

--- a/build/extension_manifest.json
+++ b/build/extension_manifest.json
@@ -36,7 +36,6 @@
 			"*://tr.wikipedia.org/*title=Özel:*",
 			"*://es.wikipedia.org/*title=Especial:*"
 		],
-		"all_frames": true,
 		"js": [ "js/contentScript.js" ],
 		"css": [ "generated.whowrotethat.css" ],
 		"run_at": "document_end"


### PR DESCRIPTION
Although I haven't quite figured out what's causing it, there are
times when the content script is injected twice. This adds a
guard against this, and even if it's not tackling the root cause
it shoudln't be too harmful a check to add.

This also removes the 'content_scripts.all_frames' setting from
manifest.json, returning it to its default value of false (meaning
that the script will only be loaded for the topmost frame in a
tab). This shouldn't change anything, because Wikipedia never
loads itself in a frame, but it seemed like a good guess as to
why things were loading twice (they still were even without it...).

https://phabricator.wikimedia.org/T232460

Bug: T232460