### PR TITLE
Re-initialize the model on VE deactivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent the extension script from loading more than once on a Wikipedia page
 - Don't gray out tables as they can contain tokenized elements
 - Use our standard debug log format (for VE activation/deactivation messages)
+- Correctly re-initialize WWT after VE deactivation
 
 ### Changed
 - Translation updates

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -145,6 +145,11 @@ class Controller {
 			} );
 			mw.hook( 've.deactivationComplete' ).add( () => {
 				Tools.log( 'VisualEditor deactivated, enabling system.' );
+
+				// Re-initialize the model, repeating what's done in browserextension.js
+				// This is due to VE replacing the content element,
+				// rather than inserting new contents into it.
+				this.model.initialize( $( '.mw-parser-output' ), config );
 				this.model.toggleEnabled( true );
 			} );
 

--- a/src/Model.js
+++ b/src/Model.js
@@ -26,9 +26,10 @@ class Model extends EventEmitter {
 	}
 
 	/**
-	 * Initialize the model with the given content and configuration
-	 * This is done after the class is instantiated, when we are certain
-	 * that the DOM loaded with all gadgets ready.
+	 * Initialize the model with the given content and configuration.
+	 * This is done after the class is instantiated, when we are certain that the DOM loaded with
+	 * all gadgets ready. It is also done when VE is deactivated, to inject the newly-created
+	 * $content object.
 	 *
 	 * @param {jQuery} $content jQuery object representing the content
 	 * @param {Object} config Configuration object


### PR DESCRIPTION
VE replaces the entire content element, rather than just its
contents, and so our reference to it is no longer part of
the DOM. Re-initializing gives the model a reference to the
new element.

https://phabricator.wikimedia.org/T235015

Bug: T235015