### PR TITLE
Remove out of date function argument

### DIFF
--- a/src/Controller.js
+++ b/src/Controller.js
@@ -193,7 +193,7 @@ class Controller {
 
 			this.model.toggleActive( true );
 			this.model.setState( 'pending' );
-			return this.api.getData( window.location.href )
+			return this.api.getData()
 				.then(
 					// Success handler.
 					result => {


### PR DESCRIPTION
We no longer need to pass the current URL to Api.getData()