### PR TITLE
Move click handler from button to the link inside the button

### DIFF
--- a/src/Controller.js
+++ b/src/Controller.js
@@ -16,7 +16,8 @@ class Controller {
 	constructor() {
 		if ( !Controller.instance ) {
 			this.initialized = false;
-			this.link = null;
+			this.$button = null;
+			this.$link = null;
 			this.namespace = null;
 			this.mainPage = false;
 			this.translations = {};
@@ -125,14 +126,6 @@ class Controller {
 				)
 			);
 
-			// Add a portlet link to 'tools'
-			this.link = mw.util.addPortletLink(
-				'p-tb',
-				'#',
-				mw.msg( 'whowrotethat-activation-link' ),
-				't-whowrotethat',
-				mw.msg( 'whowrotethat-activation-link-tooltip' )
-			);
 			// Initial state
 			this.getButton().toggle( this.model.isEnabled() );
 
@@ -273,13 +266,13 @@ class Controller {
 	 * @param {boolean} [active] The state to toggle to.
 	 */
 	toggleLinkActiveState( active ) {
-		const anchor = this.link.querySelector( 'a' );
+		const $link = this.getLink();
 		if ( active ) {
-			anchor.textContent = mw.msg( 'whowrotethat-deactivation-link' );
-			anchor.title = '';
+			$link.text( mw.msg( 'whowrotethat-deactivation-link' ) );
+			$link.removeAttr( 'title' );
 		} else {
-			anchor.textContent = mw.msg( 'whowrotethat-activation-link' );
-			anchor.title = mw.msg( 'whowrotethat-activation-link-tooltip' );
+			$link.text( mw.msg( 'whowrotethat-activation-link' ) );
+			$link.attr( 'title', mw.msg( 'whowrotethat-activation-link-tooltip' ) );
 		}
 	}
 
@@ -311,12 +304,38 @@ class Controller {
 	}
 
 	/**
-	 * Get the jQuery object representing the activation button
+	 * Get the activation button (which contains the activation link).
+	 * Will add it if it doesn't already exist in the DOM.
 	 *
-	 * @return {jQuery} Activation button
+	 * @return {jQuery} Activation button.
 	 */
 	getButton() {
-		return $( this.link );
+		// If it's already been added to the DOM, return it.
+		if ( this.$button instanceof $ ) {
+			return this.$button;
+		}
+		// Otherwise, add a portlet link to the 'toolbox' portlet.
+		this.$button = $( mw.util.addPortletLink(
+			'p-tb',
+			'#',
+			mw.msg( 'whowrotethat-activation-link' ),
+			't-whowrotethat',
+			mw.msg( 'whowrotethat-activation-link-tooltip' )
+		) );
+		return this.$button;
+	}
+
+	/**
+	 * Get the activation link, from inside the activation button.
+	 *
+	 * @return {jQuery} Activation link.
+	 */
+	getLink() {
+		if ( this.$link instanceof $ ) {
+			return this.$link;
+		}
+		this.$link = this.getButton().find( 'a' );
+		return this.$link;
 	}
 }
 

--- a/src/outputs/browserextension.js
+++ b/src/outputs/browserextension.js
@@ -5,12 +5,12 @@ config.outputEnvironment = 'Browser extension';
 
 ( function () {
 	/**
-	 * A method responding to click on the activation button
+	 * A method responding to click on the activation link.
 	 *
 	 * @param  {jQuery.Event} e Event data
 	 * @return {boolean} false
 	 */
-	const onActivateButtonClick = e => {
+	const onActivationLinkClick = e => {
 			wwtController.toggle();
 			e.preventDefault();
 			return false;
@@ -96,7 +96,7 @@ config.outputEnvironment = 'Browser extension';
 					wikiWhoUrl: config.wikiWhoUrl
 				}
 			);
-			wwtController.getButton().on( 'click', onActivateButtonClick );
+			wwtController.getLink().on( 'click', onActivationLinkClick );
 
 			// Check whether to load the tour
 			if (


### PR DESCRIPTION
This might seem like an overly-large change for this little tweak,
but most of what it's doing is making the nomenclature for the
button and the link more consistent. The button is the `<li>` and
the link is the `<a>` inside it.

This patch also moves the creation of the portlet into the
getButton(), so we don't have the odd create-then-retrieve flow
in initialize(). And it turns both button and link into jQuery
objects, so we don't have to think too hard about whether they're
jQuery or HTMLElements (could have gone the other way, and done
them both as HTMLElements, but we want to use jQuery's toggle()
on them, so this is less code).

https://phabricator.wikimedia.org/T239842

Bug: T239842