### PR TITLE
Don't gray out elements with no visible content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build: Provide valid Gecko-ID for local development
 - Prevent the extension script from loading more than once on a Wikipedia page
 - Don't gray out tables as they can contain tokenized elements
+- Don't gray out empty elements.
 - Use our standard debug log format (for VE activation/deactivation messages)
 - Correctly re-initialize WWT after VE deactivation
 

--- a/src/App.js
+++ b/src/App.js
@@ -147,8 +147,12 @@ class App {
 		// Add the class to immediate children of the parser output
 		// that don't contain tokenized elements.
 		$.each( $content, ( _i, el ) => {
-			if ( !$( el ).hasClass( 'editor-token' ) && !$( el ).find( '.editor-token' ).length ) {
-				$( el ).addClass( 'wwt-disabled' )
+			const $el = $( el );
+			if ( !$el.hasClass( 'editor-token' ) && !$el.find( '.editor-token' ).length &&
+				// Don't gray out nodes with no visible content. See T235130#5725001.
+				!!$el.text().trim() && !$el.is( ':visible' )
+			) {
+				$el.addClass( 'wwt-disabled' )
 					// Remove .wtt-disabled elements added above to prevent compounding opacity.
 					.find( '.wwt-disabled' )
 					.removeClass( 'wwt-disabled' );


### PR DESCRIPTION
This is primarily to exclude empty `<p>` elements (possibly containing
only a `<br/>`), which is common in MediaWiki.

Bug: T235130