### PR TITLE
Fix 2nd shimmer in revision popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't gray out empty elements.
 - Use our standard debug log format (for VE activation/deactivation messages)
 - Correctly re-initialize WWT after VE deactivation
+- Return to showing two 'shimmer' lines while loading the edit summary in a revision popup
 
 ### Changed
 - Translation updates

--- a/src/RevisionPopupWidget.js
+++ b/src/RevisionPopupWidget.js
@@ -64,9 +64,9 @@ function getCommentHtml( data, isCached ) {
 
 	if ( data.comment === undefined && !isCached ) {
 		// Not yet available.
-		const $shimmerSpan = $( '<div>' )
+		const $shimmerSpan = $( '<span>' )
 			.addClass( 'wwt-shimmer wwt-shimmer-animation' );
-		$revCommentSpan.append( $shimmerSpan, $shimmerSpan );
+		$revCommentSpan.append( $shimmerSpan, $shimmerSpan.clone() );
 	} else if ( data.comment !== '' ) {
 		const $commentSpan = $( '<span>' )
 			.addClass( 'comment comment--without-parentheses' )


### PR DESCRIPTION
The second shimmer line was not being added correctly because
$.append() saw it as the same element. Cloning it fixes this.

https://phabricator.wikimedia.org/T236702
Bug: T236702