### PR TITLE
Fix revision details popup for image thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correctly re-initialize WWT after VE deactivation
 - Return to showing two 'shimmer' lines while loading the edit summary in a revision popup
 - Show infobar on top of page status indicators.
+- Show revision detials popup for image thumbnails.
 
 ### Changed
 - Translation updates

--- a/src/App.js
+++ b/src/App.js
@@ -170,6 +170,7 @@ class App {
 	 */
 	attachContentListeners( $content ) {
 		$content.find( '.editor-token' )
+			.addBack( '.editor-token' )
 			.on( 'mouseenter', e => {
 				if ( this.revisionPopup.isVisible() ) {
 					return;


### PR DESCRIPTION
Look for .editor-token elements that are immediate children of the
parser output, and not just further descendants.

Bug: T239112