### PR TITLE
Add loading loop to wait for mw.loader.using to be available

### DIFF
--- a/src/outputs/browserextension.js
+++ b/src/outputs/browserextension.js
@@ -106,10 +106,21 @@ config.outputEnvironment = 'Browser extension';
 				loadWhoWroteThatWelcomeTour();
 			}
 
+		},
+		/**
+		 * Load dependency modules and then WWT,
+		 * waiting (if required) for the startup module to finish loading.
+		 */
+		loadDependencies = () => {
+			if ( mw.loader.using === undefined ) {
+				setTimeout( loadDependencies, 100 );
+				return;
+			}
+			mw.loader.using( [ 'jquery', 'mediawiki.base', 'mediawiki.api', 'mediawiki.util', 'mediawiki.jqueryMsg' ], loadWhoWroteThat );
 		};
 
 	var q = window.RLQ || ( window.RLQ = [] );
-	q.push( [ [ 'jquery', 'mediawiki.base', 'mediawiki.util', 'mediawiki.jqueryMsg' ], loadWhoWroteThat ] );
+	q.push( loadDependencies );
 
 	// For debugging purposes, export methods to the window global
 	window.wwtDebug = {


### PR DESCRIPTION
This is because the Resource Loader queue is first processed by
the startup module, and it seems that we (sometimes only) get in
too quickly and it's not ready. This is a bit of a hack.