### PR TITLE
Stop load if we are on an invalid page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent the WhoWroteThat button from appearing on the main page.
 
 ## [0.11.0] - 2019-12-13
 ### Added

--- a/src/outputs/browserextension.js
+++ b/src/outputs/browserextension.js
@@ -96,13 +96,16 @@ config.outputEnvironment = 'Browser extension';
 					wikiWhoUrl: config.wikiWhoUrl
 				}
 			);
+
+			if ( !wwtController.getModel().isValidPage() ) {
+				// Only continue if we're in a valid page
+				return;
+			}
+
 			wwtController.getLink().on( 'click', onActivationLinkClick );
 
 			// Check whether to load the tour
-			if (
-				$( 'html' ).hasClass( 'wwt-welcome-tour-unseen' ) &&
-				wwtController.getModel().isValidPage()
-			) {
+			if ( $( 'html' ).hasClass( 'wwt-welcome-tour-unseen' ) ) {
 				loadWhoWroteThatWelcomeTour();
 			}
 


### PR DESCRIPTION
This used to work, but when we changed the way we call the button,
it still got attached to the DOM even though the system in general
is inoperable.

This commit fixes it by adding the 'isValidPage' check before we
call the button and attach the event on it at all, so a button
isn't created and events aren't attached unnecessarily.

Bug: https://phabricator.wikimedia.org/T240690