### PR TITLE
Restore comment fading in, with jQuery fadeIn()

### DIFF
--- a/src/RevisionPopupWidget.js
+++ b/src/RevisionPopupWidget.js
@@ -74,10 +74,11 @@ function getCommentHtml( data, isCached ) {
 		$revCommentSpan.prepend( $( '<br>' ), $commentSpan );
 
 		if ( !isCached ) {
-			$commentSpan
-				.addClass( 'wwt-revisionPopupWidget-comment-animated' );
+			// Hide the newly-added comment and diff size, to be shown later
+			// (in show() below, after it's been added to the DOM).
 			$revCommentSpan
-				.addClass( 'wwt-revisionPopupWidget-comment-transparent' );
+				.addClass( 'wwt-revisionPopupWidget-comment-needs-fadein' )
+				.hide();
 		}
 	}
 	return $revCommentSpan;
@@ -162,10 +163,8 @@ RevisionPopupWidget.prototype.show = function ( data, $target, isCached ) {
 	this.setFloatableContainer( $target );
 	this.toggle( true );
 
-	// Animate edit summary, if present.
-	if ( data.comment ) {
-		$( '.wwt-revisionPopupWidget-comment' ).removeClass( 'wwt-revisionPopupWidget-comment-transparent' );
-	}
+	// Animate edit summary, if needed. This class was added above in getCommentHtml().
+	$( '.wwt-revisionPopupWidget-comment-needs-fadein' ).fadeIn( 1000 );
 };
 
 export default RevisionPopupWidget;

--- a/src/less/RevisionPopupWidget.less
+++ b/src/less/RevisionPopupWidget.less
@@ -19,15 +19,6 @@
 	margin-top: 8px;
 }
 
-.wwt-revisionPopupWidget-comment-animated {
-	transition: opacity 1s;
-	opacity: 1;
-}
-
-.wwt-revisionPopupWidget-comment-animated-transparent {
-	opacity: 0;
-}
-
 /* Adapted from http://cloudcannon.com/deconstructions/2014/11/15/facebook-content-placeholder-deconstruction.html */
 
 @keyframes wwt-placeHolderShimmer {


### PR DESCRIPTION
This does away with the custom fading in that we were using
before the comment was a jQuery object, and makes the fading-in
work again.

https://phabricator.wikimedia.org/T236702