### PR TITLE
Rework display of usernames and RevisionPopup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Prevent the WhoWroteThat button from appearing on the main page.
 
+### Changed
+- Fetch username from the MediaWiki API, and fade-in all content in the revision popup.
+
 ## [0.11.0] - 2019-12-13
 ### Added
 - This change log.

--- a/src/App.js
+++ b/src/App.js
@@ -175,17 +175,14 @@ class App {
 				if ( this.revisionPopup.isVisible() ) {
 					return;
 				}
-				const ids = this.getIdsFromElement( e.currentTarget ),
-					tokenInfo = wwtController.getApi().getTokenInfo( ids.tokenId );
+				const ids = this.getIdsFromElement( e.currentTarget );
 				this.activateSpans( $content, ids.editorId );
-				this.widget.setUsernameInfo( tokenInfo.username );
 			} )
 			.on( 'mouseleave', () => {
 				if ( this.revisionPopup.isVisible() ) {
 					return;
 				}
 				this.deactivateSpans( $content );
-				this.widget.clearUsernameInfo();
 			} )
 			.on( 'click', e => {
 				const ids = this.getIdsFromElement( e.currentTarget ),
@@ -193,17 +190,15 @@ class App {
 					isCached = wwtController.getApi().isCached( tokenInfo.revisionId );
 
 				this.activateSpans( $content, ids.editorId );
-				this.widget.setUsernameInfo( tokenInfo.username );
 				this.revisionPopup.show( tokenInfo, $( e.currentTarget ), isCached );
 				this.revisionPopup.once( 'toggle', () => {
 					this.deactivateSpans( $content );
-					this.widget.clearUsernameInfo();
 				} );
 
 				// eslint-disable-next-line one-var
 				const reqStartTime = Date.now();
-				// Fetch edit summary then re-render the popup.
-				wwtController.getApi().fetchEditSummary( tokenInfo.revisionId )
+				// Fetch revision data then re-render the popup.
+				wwtController.getApi().fetchRevisionData( tokenInfo.revisionId )
 					.then( successData => {
 						const delayTime = (
 							!isCached &&
@@ -213,14 +208,14 @@ class App {
 						Object.assign( tokenInfo, successData );
 
 						setTimeout( () => {
-							this.revisionPopup.show( tokenInfo, $( e.target ) );
+							this.revisionPopup.show( tokenInfo, $( e.target ), isCached );
 						}, delayTime );
 					}, () => {
 						// Silently fail. The revision info provided by WikiWho
 						// is still present, which is the important part,
 						// so we'll just show what we have and throw a console
 						// warning.
-						mw.log.warn( `WhoWroteThat failed to fetch the summary for revision ${tokenInfo.revisionId}` );
+						mw.log.warn( `WhoWroteThat failed to fetch data for revision with ID ${tokenInfo.revisionId}` );
 					} );
 			} );
 

--- a/src/InfoBarWidget.js
+++ b/src/InfoBarWidget.js
@@ -136,18 +136,4 @@ InfoBarWidget.prototype.setErrorMessage = function ( errCode = 'refresh' ) {
 	this.setLabel( new OO.ui.HtmlSnippet( mw.msg( 'whowrotethat-state-error', errorMessage ) ) );
 };
 
-/**
- * Show the given username information
- *
- * @param {string} username
- */
-InfoBarWidget.prototype.setUsernameInfo = function ( username ) {
-	this.userInfoUsernameLabel.setLabel( $( '<span>' ).append( Tools.bidiIsolate( username ) ).contents() );
-};
-
-// Clear the username information
-InfoBarWidget.prototype.clearUsernameInfo = function () {
-	this.userInfoUsernameLabel.setLabel( '' );
-};
-
 export default InfoBarWidget;

--- a/src/RevisionPopupWidget.js
+++ b/src/RevisionPopupWidget.js
@@ -27,7 +27,7 @@ OO.inheritClass( RevisionPopupWidget, OO.ui.PopupWidget );
  * @param {number} size
  * @return {jQuery}
  */
-function getSizeHtml( size ) {
+function getSizeContent( size ) {
 	const $diffBytes = $( '<span>' );
 	$diffBytes.addClass( 'mw-diff-bytes' );
 
@@ -54,31 +54,18 @@ function getSizeHtml( size ) {
  * returned HTML will start with a <br>; if there is no summary, it wont (so it can be appended to
  * the revision author information).
  * @param {Object} data As returned by Api.prototype.getTokenInfo().
- * @param {boolean} [isCached] Comment promise is cached
  * @return {jQuery}
  */
-function getCommentHtml( data, isCached ) {
+function getCommentContent( data ) {
 	const $revCommentSpan = $( '<span>' )
 		.addClass( 'wwt-revisionPopupWidget-comment' )
-		.append( $( '<span>' ).text( ' ' ), getSizeHtml( data.size ) );
+		.append( $( '<span>' ).text( ' ' ), getSizeContent( data.size ) );
 
-	if ( data.comment === undefined && !isCached ) {
-		// Not yet available.
-		const $shimmerSpan = $( '<span>' )
-			.addClass( 'wwt-shimmer wwt-shimmer-animation' );
-		$revCommentSpan.append( $shimmerSpan, $shimmerSpan.clone() );
-	} else if ( data.comment !== '' ) {
+	if ( data.comment !== '' ) {
 		const $commentSpan = $( '<span>' )
 			.addClass( 'comment comment--without-parentheses' )
 			.append( Tools.bidiIsolate( $.parseHTML( data.comment ) ) );
 		$revCommentSpan.prepend( $( '<br>' ), $commentSpan );
-
-		if ( !isCached ) {
-			$commentSpan
-				.addClass( 'wwt-revisionPopupWidget-comment-animated' );
-			$revCommentSpan
-				.addClass( 'wwt-revisionPopupWidget-comment-transparent' );
-		}
 	}
 	return $revCommentSpan;
 }
@@ -88,7 +75,7 @@ function getCommentHtml( data, isCached ) {
  * @param {Object} data As returned by Api.prototype.getTokenInfo().
  * @return {jQuery}
  */
-function getUserLinksHtml( data ) {
+function getUserLinksContent( data ) {
 	const contribsUrl = mw.util.getUrl( `Special:Contributions/${data.username}` ),
 		// We typically link to Special:Contribs for IPs.
 		userPageUrl = data.isIP ? contribsUrl : mw.util.getUrl( `User:${data.username}` );
@@ -125,14 +112,23 @@ function getUserLinksHtml( data ) {
 }
 
 /**
- * Show the revision popup based on the given token data, above the given element.
- * Note that the English namespaces will normalize to the wiki's local namespaces.
- * @param {Object} data As returned by Api.prototype.getTokenInfo().
- * @param {jQuery} $target Element the popup should be attached to.
- * @param {boolean} [isCached] Whether the comment promise is available, cached.
+ * Get content for the loading state.
+ * @return {jQuery}
  */
-RevisionPopupWidget.prototype.show = function ( data, $target, isCached ) {
-	const $userLinks = getUserLinksHtml( data ),
+function getLoadingStateContent() {
+	const $shimmerSpan = $( '<span>' )
+		.addClass( 'wwt-shimmer wwt-shimmer-animation' );
+	return $( '<div>' )
+		.append( $shimmerSpan, $shimmerSpan.clone(), $shimmerSpan.clone() );
+}
+
+/**
+ * Get content for the popup, called once data has been retrieved from the API.
+ * @param {Object} data
+ * @return {jQuery}
+ */
+function getContent( data ) {
+	const $userLinks = getUserLinksContent( data ),
 		dateStr = moment( data.revisionTime ).locale( mw.config.get( 'wgUserLanguage' ) ).format( 'LLL' ),
 		// Use jQuery to make sure attributes are properly escaped
 		$diffLink = $( '<a>' )
@@ -146,11 +142,37 @@ RevisionPopupWidget.prototype.show = function ( data, $target, isCached ) {
 		$scorePercent = $( '<strong>' ).text( mw.msg( scoreMsgKey + '-percent', data.score ) ),
 		$attributionMsg = $( '<div>' )
 			.addClass( 'wwt-revisionPopupWidget-attribution' )
-			.html( Tools.i18nHtml( scoreMsgKey, $scorePercent ) ),
-		$html = $( '<div>' )
-			.append( addedMsg, getCommentHtml( data, isCached ), $attributionMsg );
-	this.$popupContent.empty().append( $html );
+			.html( Tools.i18nHtml( scoreMsgKey, $scorePercent ) );
 
+	return $( '<div>' )
+		.append( addedMsg, getCommentContent( data ), $attributionMsg );
+}
+
+/**
+ * Show the revision popup based on the given token data, above the given element.
+ * Note that the English namespaces will normalize to the wiki's local namespaces.
+ * @param {Object} data As returned by Api.prototype.getTokenInfo().
+ * @param {jQuery} $target Element the popup should be attached to.
+ * @param {boolean} [isCached] Whether the comment promise is available, cached.
+ */
+RevisionPopupWidget.prototype.show = function ( data, $target, isCached ) {
+	let $content;
+
+	// If data.comment is undefined, we are in the loading state.
+	if ( data.comment === undefined ) {
+		$content = getLoadingStateContent();
+	} else {
+		$content = getContent( data );
+
+		if ( !isCached ) {
+			$content.addClass( 'wwt-revisionPopupWidget-animate' );
+		}
+	}
+
+	this.$popupContent.empty().append( $content );
+
+	// Ensure the popup is attached to the visible content,
+	// which it otherwise wouldn't be for image thumbnails.
 	if ( $target.find( '.thumb' ).length ) {
 		$target = $target.find( '.thumb' );
 	}
@@ -162,10 +184,9 @@ RevisionPopupWidget.prototype.show = function ( data, $target, isCached ) {
 	this.setFloatableContainer( $target );
 	this.toggle( true );
 
-	// Animate edit summary, if present.
-	if ( data.comment ) {
-		$( '.wwt-revisionPopupWidget-comment' ).removeClass( 'wwt-revisionPopupWidget-comment-transparent' );
-	}
+	// Animate content once loaded.
+	$( '.wwt-revisionPopupWidget-animate' )
+		.addClass( 'wwt-revisionPopupWidget-animate-visible' );
 };
 
 export default RevisionPopupWidget;

--- a/src/less/RevisionPopupWidget.less
+++ b/src/less/RevisionPopupWidget.less
@@ -1,3 +1,14 @@
+@line-break-height: 8px;
+
+.wwt-revisionPopupWidget-animate {
+	transition: opacity 1s;
+	opacity: 0;
+}
+
+.wwt-revisionPopupWidget-animate-visible {
+	opacity: 1;
+}
+
 .mw-diff-bytes {
 	font-style: italic;
 }
@@ -11,21 +22,13 @@
 
 /* Prevent 1-pixel jumping of when shimmer disappears and a 2-line summary appears. */
 .wwt-shimmer:last-of-type {
-	margin-bottom: 8px;
+	margin-bottom: @line-break-height;
+	margin-top: @line-break-height * 2;
 }
 
 .wwt-revisionPopupWidget-comment,
 .wwt-revisionPopupWidget-attribution {
-	margin-top: 8px;
-}
-
-.wwt-revisionPopupWidget-comment-animated {
-	transition: opacity 1s;
-	opacity: 1;
-}
-
-.wwt-revisionPopupWidget-comment-animated-transparent {
-	opacity: 0;
+	margin-top: @line-break-height;
 }
 
 /* Adapted from http://cloudcannon.com/deconstructions/2014/11/15/facebook-content-placeholder-deconstruction.html */


### PR DESCRIPTION
Remove display of username/IP from infobar.

Fetch the username from the MediaWiki API along with the other revision
data.

Minor refactoring of RevisionPopupWidget, renaming some methods to say
"content" instead of "html" for clarity, since they are returning
jQuery objects.

Bug: https://phabricator.wikimedia.org/T240707