### PR TITLE
New Grunt task to check Firefox addons listing messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9215,6 +9215,12 @@
             "semver": "^5.7.0"
          }
       },
+      "node-fetch": {
+         "version": "2.6.0",
+         "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+         "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+         "dev": true
+      },
       "node-forge": {
          "version": "0.7.6",
          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
       "jsdoc-wmf-theme": "^0.0.3",
       "jsdom": "~15.1.1",
       "mocha": "^6.2.0",
+      "node-fetch": "^2.6.0",
       "stylelint": "^10.1.0",
       "stylelint-config-wikimedia": "0.6.0",
       "web-ext": "^3.2.0"


### PR DESCRIPTION
This adds the checkListings[:beta] task, which retrieves the
extension's data from the Firefox store and compares the name
and description with what's in the local i18n files.

Bug: https://phabricator.wikimedia.org/T239840