### PR TITLE
Refactor RevisionPopupWidget for MVC

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -225,6 +225,32 @@ class Model extends EventEmitter {
 			this.emit( 'state', this.state, errorCode );
 		}
 	}
+
+	/**
+	 * Set the token that is currently active.
+	 * Emit an event so widgets can update themselves,
+	 * based on the loading state and data.
+	 *
+	 * @param {Object} tokenData Token data
+	 * @param {jQuery} $target jQuery element for the clicked token
+	 * @param {string} state Loading state: 'pending', 'success' or 'failure'
+	 */
+	setCurrentToken( tokenData, $target, state ) {
+		/**
+		 * Token has been set as active
+		 *
+		 * @event Model#setToken
+		 * @param {string} state Loading state
+		 * @param {jQuery} jQuery element representing the clicked token
+		 * @param {Object} tokenData Token data
+		 */
+		this.emit(
+			'setToken',
+			state,
+			$target,
+			tokenData
+		);
+	}
 }
 
 export default Model;

--- a/src/less/RevisionPopupWidget.less
+++ b/src/less/RevisionPopupWidget.less
@@ -1,5 +1,9 @@
 @line-break-height: 8px;
 
+.wwt-revisionPopupWidget-content {
+	padding: 0.5em;
+}
+
 .wwt-revisionPopupWidget-animate {
 	transition: opacity 1s;
 	opacity: 0;


### PR DESCRIPTION
We've changed the system to use MVC but didn't really touch the
widget, so it had a lot of its own logic. That logic didn't quite
fit the new features we want (and are about to tweak) like extending
some of the pending animation to more than the comment, or adding
more of the dynamic information within the promises and events.

This commit refactors the widget to listen to the model and respond
to refresh events, and have the click event trigger the controller
to utilize the API. It means, among other things, that --
- We don't need to deliver extra data like isCached between the
  MVC barriers,
- It should be a little more organized with some clear order of
  operations
- The popup doesn't constantly get rebuilt -- it builds its structure
  and only replaces the actual data when updated.

Bug: https://phabricator.wikimedia.org/T241004