### PR TITLE
Normalize lang code in model to lowercase

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -41,7 +41,7 @@ class Model extends EventEmitter {
 	 */
 	initialize( $content, config ) {
 		this.$contentWrapper = $content;
-		this.lang = config.lang || 'en';
+		this.lang = config.lang ? config.lang.toLowerCase() : 'en';
 		this.namespace = config.namespace || '';
 		this.mainPage = !!config.mainPage;
 		this.revisionId = config.revisionId || 0;


### PR DESCRIPTION
Setting a language via ?uselang=pt-br results in lang="pt-BR" being added to the HTML, where WWT reads it from. This change normalizes this to match the letter case of the translation files, so when we load them in the Controller they are correctly in the translations object.

https://phabricator.wikimedia.org/T239634