### PR TITLE
Use wgUserLanguage instead of the html lang attribute

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -41,7 +41,7 @@ class Model extends EventEmitter {
 	 */
 	initialize( $content, config ) {
 		this.$contentWrapper = $content;
-		this.lang = config.lang ? config.lang.toLowerCase() : 'en';
+		this.lang = config.lang || 'en';
 		this.namespace = config.namespace || '';
 		this.mainPage = !!config.mainPage;
 		this.revisionId = config.revisionId || 0;

--- a/src/outputs/browserextension.js
+++ b/src/outputs/browserextension.js
@@ -87,7 +87,7 @@ config.outputEnvironment = 'Browser extension';
 			wwtController.initialize(
 				$( '.mw-parser-output' ),
 				{
-					lang: $( 'html' ).attr( 'lang' ),
+					lang: mw.config.get( 'wgUserLanguage' ),
 					translations: languageBlob,
 					namespace: mw.config.get( 'wgCanonicalNamespace' ),
 					mainPage: mw.config.get( 'wgIsMainPage' ),


### PR DESCRIPTION
This also reverts the workaround that I added in #132 because it's
no longer required.

Bug: T239634