### PR TITLE
Correct display of revision popup content

### DIFF
--- a/src/RevisionPopupWidget.js
+++ b/src/RevisionPopupWidget.js
@@ -22,7 +22,6 @@ const RevisionPopupWidget = function RevisionPopupWidget( model, config = {} ) {
 	// Parent constructor
 	RevisionPopupWidget.parent.call( this, Object.assign(
 		{
-			padded: true,
 			autoClose: true,
 			position: 'above',
 			// FIXME: 'force-left' for RTL languages
@@ -35,6 +34,8 @@ const RevisionPopupWidget = function RevisionPopupWidget( model, config = {} ) {
 
 	this.initialize();
 	this.model.on( 'setToken', this.onModelSetToken.bind( this ) );
+	this.$element
+		.addClass( 'wwt-revisionPopupWidget' );
 };
 
 /* Setup */
@@ -93,6 +94,7 @@ RevisionPopupWidget.prototype.initialize = function () {
 	this.commentLabel = new OO.ui.LabelWidget();
 
 	this.revisionAddedLabel = new OO.ui.LabelWidget( {
+		classes: [ 'wwt-revisionPopupWidget-revisionAdded' ]
 	} );
 
 	this.scoreLabel = new OO.ui.LabelWidget( {
@@ -175,6 +177,9 @@ RevisionPopupWidget.prototype.updateData = function ( data = {} ) {
 	this.commentLabel.$element
 		.toggleClass( 'comment', !!data.comment )
 		.toggleClass( 'comment--without-parentheses', !!data.comment );
+	this.$element
+		.toggleClass( 'wwt-revisionPopupWidget-hasComment', !!data.comment )
+		.toggleClass( 'wwt-revisionPopupWidget-noComment', !data.comment );
 
 	// Diff size
 	this.diffSizeLabel.$element

--- a/src/less/RevisionPopupWidget.less
+++ b/src/less/RevisionPopupWidget.less
@@ -1,38 +1,66 @@
 @line-break-height: 8px;
 
-.wwt-revisionPopupWidget-content {
-	padding: 0.5em;
-}
+.wwt-revisionPopupWidget {
+	&-content {
+		padding: 0.75em 0.5em;
+	}
 
-.wwt-revisionPopupWidget-animate {
-	transition: opacity 1s;
-	opacity: 0;
-}
+	&-animate {
+		transition: opacity 1s;
+		opacity: 0;
 
-.wwt-revisionPopupWidget-animate-visible {
-	opacity: 1;
-}
+		&-visible {
+			opacity: 1;
+		}
+	}
 
-.mw-diff-bytes {
-	font-style: italic;
-}
+	&-revisionAdded.oo-ui-labelWidget {
+		display: inline;
 
-.wwt-shimmer {
-	display: block;
-	height: 18px;
-	margin-bottom: 9px;
-	width: 100%;
-}
+		.wwt-revisionPopupWidget-hasComment & {
+			// If there's a comment, it should go to its own line.
+			// Otherwise, if there's no comment, we want the diff-size
+			// to appear on the same line as the revision-added
+			// details line. This is declared as display:inline;
+			// already, so we just set it to block if a comment
+			// exists.
+			display: block;
+			margin-bottom: @line-break-height;
+		}
+		word-break: break-word;
+	}
 
-/* Prevent 1-pixel jumping of when shimmer disappears and a 2-line summary appears. */
-.wwt-shimmer:last-of-type {
-	margin-bottom: @line-break-height;
-	margin-top: @line-break-height * 2;
-}
+	.comment {
+		display: inline;
+		font-style: italic;
+		word-break: break-word;
+	}
 
-.wwt-revisionPopupWidget-comment,
-.wwt-revisionPopupWidget-attribution {
-	margin-top: @line-break-height;
+	.mw-diff-bytes {
+		display: inline;
+		font-style: italic;
+		margin-left: 0.25em;
+	}
+
+	// Must make the rule more specific to override the rules
+	// of oo.ui.widget which override these otherwise
+	&-attribution.oo-ui-labelWidget {
+		display: block;
+		margin-top: @line-break-height;
+	}
+
+	.wwt-shimmer {
+		display: block;
+		height: 18px;
+		margin-bottom: 9px;
+		width: 100%;
+	}
+
+	/* Prevent 1-pixel jumping of when shimmer disappears and a 2-line summary appears. */
+	.wwt-shimmer:last-of-type {
+		margin-bottom: @line-break-height;
+		margin-top: @line-break-height * 2;
+	}
 }
 
 /* Adapted from http://cloudcannon.com/deconstructions/2014/11/15/facebook-content-placeholder-deconstruction.html */


### PR DESCRIPTION
After the refactor and especially after we've changed the way
that the content loads in the popup (loading usernames from the
mediawiki API rather than showing them outright while other content
loads, etc) the display and structure of the popup needed to be
readjusted.

In this commit:
- Reorganize the LESS structure so all css classes are scoped for
  within the popup, and do not leak for mw classes outside of it.
  (Fixes bug https://phabricator.wikimedia.org/T241998)
- Wrap long usernames (and IPv6 usernames)
- Add spacing after diff numbers, but only if there is a comment
- Bring back the italicization of the comment.
- Place the size diff at the intro line if there's no comment,
  or near the comment if that comment exists.
- Set padding at 0.75em and 0.5em for the popup (see T242954)

Bug: https://phabricator.wikimedia.org/T241004
Bug: https://phabricator.wikimedia.org/T242954