### PR TITLE
Add message when edit summary is hidden

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -27,5 +27,6 @@
 	"whowrotethat-revision-attribution-percent": "$1%",
 	"whowrotethat-revision-attribution-lessthan": "They have written $1 of the page.",
 	"whowrotethat-revision-attribution-lessthan-percent": "less than 1%",
-	"whowrotethat-revision-deleted-username": "(username or IP removed)"
+	"whowrotethat-revision-deleted-username": "(username or IP removed)",
+	"whowrotethat-revision-edit-summary-hidden": "(edit summary removed)"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -32,5 +32,7 @@
 	"whowrotethat-revision-attribution-percent": "Emphasised percentage of authorship, to be inserted into {{msg-wm|whowrotethat-revision-attribution}}.",
 	"whowrotethat-revision-attribution-lessthan": "Message indicating that the author has edited less than 1% of the page.\n\n{{Doc-singularthey}}\n\nThis is shown immediately after the {{msg-wm|whowrotethat-revision-added}} message.",
 	"whowrotethat-revision-attribution-lessthan-percent": "Emphasised percentage of authorship, to be inserted into {{msg-wm|whowrotethat-revision-attribution-lessthan}}.",
-	"whowrotethat-revision-deleted-username": "Message shown instead of the username if the username has been removed from public view."
+	"whowrotethat-revision-deleted-username": "Message shown instead of the username if the username has been removed from public view.",
+	"whowrotethat-revision-edit-summary-hidden": "Message shown instead of the revision edit summary if the summary has been removed from the public view.\n\nThis is the same message as {{msg-mw|revdelete-summary-hid}}."
+
 }

--- a/src/RevisionPopupWidget.js
+++ b/src/RevisionPopupWidget.js
@@ -162,7 +162,13 @@ RevisionPopupWidget.prototype.updateData = function ( data = {} ) {
 	// Comment content
 	this.commentLabel.setLabel(
 		new OO.ui.HtmlSnippet(
-			Tools.bidiIsolate( $.parseHTML( data.comment ) )
+			data.comment === undefined ?
+				$( '<span>' )
+					.addClass( 'history-deleted' )
+					// Note we can't use the native MediaWiki 'revdelete-summary-hid'
+					// message because it can include parser functions.
+					.text( mw.msg( 'whowrotethat-revision-edit-summary-hidden' ) ) :
+				Tools.bidiIsolate( $.parseHTML( data.comment ) )
 		)
 	);
 


### PR DESCRIPTION
Add "edit summary removed" message when the edit summary has been hidden in the revision
details pop-up.

Bug: T241062