### PR TITLE
Correctly check for lengths of messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Correctly check for maximum lengths of the extension's names and descriptions (for Chrome store).
 
 ## [0.13.0] - 2020-01-10
 ### Added

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -213,19 +213,21 @@ module.exports = function Gruntfile( grunt ) {
 				};
 			// Name (may be for beta). Maximum length 45 characters.
 			if ( langBlob[ lang ][ nameMsg ] ) {
-				const name = langBlob[ lang ][ nameMsg ];
-				if ( name.length >= 45 ) {
-					grunt.log.error( 'The ' + lang + " '" + nameMsg + "' message must be 45 characters or less. Provided: " + name );
+				const name = langBlob[ lang ][ nameMsg ],
+					nameLengthMax = 45;
+				if ( name.length > nameLengthMax ) {
+					grunt.log.error( 'The ' + lang + " '" + nameMsg + "' message must be " + nameLengthMax + ' characters or less. Provided: ' + name );
 				}
-				locale.name.message = name.substring( 0, 44 );
+				locale.name.message = name.substring( 0, nameLengthMax );
 			}
 			// Description (may have beta appended). Maximum 132 characters.
 			if ( langBlob[ lang ][ descMsg ] ) {
-				const desc = langBlob[ lang ][ descMsg ];
-				if ( desc.length >= 132 ) {
-					grunt.log.error( 'The ' + lang + " '" + descMsg + "' message must be 132 characters or less. Provided: " + desc );
+				const desc = langBlob[ lang ][ descMsg ],
+					descLengthMax = 132;
+				if ( desc.length > descLengthMax ) {
+					grunt.log.error( 'The ' + lang + " '" + descMsg + "' message must be " + descLengthMax + ' characters or less. Provided: ' + desc );
 				}
-				locale.description.message = desc.substring( 0, 131 );
+				locale.description.message = desc.substring( 0, descLengthMax );
 			}
 			// Write the locale file. The directory name must use underscores, not hyphens.
 			let localeFile,


### PR DESCRIPTION
There was an off-by-one error in the previous check. This change
also adds variables for the max lengths.

Bug: T237756