### PR TITLE
Remove 'tabs' permission as it's not required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Removed
+- Don't ask for the [tabs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#API_permissions)
+  browser permission because it's not required.
 
 ## [0.14.0] - 2020-01-16
 ### Added

--- a/build/extension_manifest.json
+++ b/build/extension_manifest.json
@@ -41,5 +41,5 @@
 		"run_at": "document_end"
 	} ],
 	"web_accessible_resources": [ "js/generated.pageScript.js", "js/generated.welcomeTour.js" ],
-	"permissions": [ "tabs", "activeTab", "storage" ]
+	"permissions": [ "activeTab", "storage" ]
 }


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions for detalis of the `tabs` permission; we don't seem to need it.

https://phabricator.wikimedia.org/T243046