### PR TITLE
Add mw.Api to initial load dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add the `mediawiki.api` module to the initial dependencies. Fixes a bug in the loading of WWT in some cases with the welcome popup.
 
 ## [0.13.0] - 2020-01-10
 ### Added

--- a/src/outputs/browserextension.js
+++ b/src/outputs/browserextension.js
@@ -115,7 +115,7 @@ config.outputEnvironment = 'Browser extension';
 		};
 
 	var q = window.RLQ || ( window.RLQ = [] );
-	q.push( [ [ 'jquery', 'mediawiki.base', 'mediawiki.util', 'mediawiki.jqueryMsg' ], loadWhoWroteThat ] );
+	q.push( [ [ 'jquery', 'mediawiki.base', 'mediawiki.util', 'mediawiki.api', 'mediawiki.jqueryMsg' ], loadWhoWroteThat ] );
 
 	// For debugging purposes, export methods to the window global
 	window.wwtDebug = {


### PR DESCRIPTION
While initializing the controller, we're loading the WWT Api class
with an instance of mw.Api(); the initialization of the controller
happens before we run `loadDependencies` (which runs on 'launch'
because it loads all of OOUI modules we need).

While it's unclear how this didn't break before (!?) it is safer
to add `mediawiki.Api` to the initial dependencies in the RLQ loader.