### PR TITLE
Ensure attribution percentages don't wrap onto a new line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Minor styling fixes to revision details popup.
 
 ## [0.15.1] - 2020-01-22
 ### Fixed

--- a/src/RevisionPopupWidget.js
+++ b/src/RevisionPopupWidget.js
@@ -159,7 +159,9 @@ RevisionPopupWidget.prototype.updateData = function ( data = {} ) {
 		// i18n message keys for the bolded percentages are:
 		// * whowrotethat-revision-attribution-percent
 		// * whowrotethat-revision-attribution-lessthan-percent
-		$scorePercent = $( '<strong>' ).text( mw.msg( scoreMsgKey + '-percent', data.score ) );
+		$scorePercent = $( '<strong>' )
+			.text( mw.msg( scoreMsgKey + '-percent', data.score ) )
+			.addClass( 'wwt-revisionPopupWidget-attribution-percentage' );
 
 	// Comment content
 	this.commentLabel.setLabel(

--- a/src/less/RevisionPopupWidget.less
+++ b/src/less/RevisionPopupWidget.less
@@ -61,6 +61,10 @@
 		margin-bottom: @line-break-height;
 		margin-top: @line-break-height * 2;
 	}
+
+	.wwt-revisionPopupWidget-attribution-percentage {
+		white-space: nowrap;
+	}
 }
 
 /* Adapted from http://cloudcannon.com/deconstructions/2014/11/15/facebook-content-placeholder-deconstruction.html */


### PR DESCRIPTION
Some languages prefer a space between the number and the percent symbol
but this shouldn't be separated by a new line.

Bug: T242759