### PR TITLE
Remove redundant welcomeTour js file call from manifest

### DIFF
--- a/build/extension_manifest.json
+++ b/build/extension_manifest.json
@@ -40,6 +40,6 @@
 		"css": [ "generated.whowrotethat.css" ],
 		"run_at": "document_end"
 	} ],
-	"web_accessible_resources": [ "js/generated.pageScript.js", "js/generated.welcomeTour.js" ],
+	"web_accessible_resources": [ "js/generated.pageScript.js" ],
 	"permissions": [ "activeTab", "storage" ]
 }


### PR DESCRIPTION
We've consolidated the files a while ago, but apparently this
permission in manifest was never removed.