### PR TITLE
Add 'long description' message for use on browser stores

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6,6 +6,7 @@
 	"whowrotethat-ext-name-beta": "Who Wrote That? (BETA)",
 	"whowrotethat-ext-desc": "Explore authorship and revision information visually and directly in Wikipedia articles. Powered by WikiWho.",
 	"whowrotethat-ext-desc-beta": "Explore Wikipedia authorship information. Powered by WikiWho. This is the BETA version, intended for testing only.",
+	"whowrotethat-ext-longdesc": "Hover to see text by the same author. Click to see the author and revision details.",
 	"whowrotethat-activation-link": "Who Wrote That?",
 	"whowrotethat-activation-link-tooltip": "Activate Who Wrote That?",
 	"whowrotethat-deactivation-link": "Close Who Wrote That?",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -11,6 +11,7 @@
 	"whowrotethat-ext-name-beta": "The name of the beta version of the browser extension (used on the Firefox and Chrome stores). Maximum 45 characters.",
 	"whowrotethat-ext-desc": "Description of the browser extension (used on the Firefox and Chrome stores). Maximum 132 characters.",
 	"whowrotethat-ext-desc-beta": "Description of the beta version of the browser extension (used on the Firefox and Chrome stores). Maximum 132 characters.",
+	"whowrotethat-ext-longdesc": "Longer description of the browser extension. May contain paragraphs, but no HTML.",
 	"whowrotethat-activation-link": "The text for the link that turns Who Wrote That on",
 	"whowrotethat-activation-link-tooltip": "The tooltip for the link that turns Who Wrote That on",
 	"whowrotethat-deactivation-link": "The text for the link that turns Who Wrote That off",


### PR DESCRIPTION
This new message isn't used in the code anywhere, but will be
copied and pasted into the browser stores' long descriptions.

Bug: T243302