### PR TITLE
Fix padding on narrow screen vector

### DIFF
--- a/src/less/InfoBarWidget.less
+++ b/src/less/InfoBarWidget.less
@@ -52,13 +52,21 @@
 		margin-bottom: 1em;
 
 		.ltr& {
-			// content body has 1.5em padding left and right
-			margin-left: -1.5em;
+			// adjust for content body padding
+			margin-left: -1em;
+
+			@media screen and ( min-width: 982px ) {
+				margin-left: -1.5em;
+			}
 		}
 
 		.rtl& {
-			// content body has 1.5em padding left and right
-			margin-right: -1.5em;
+			// adjust for content body padding
+			margin-right: -1em;
+
+			@media screen and ( min-width: 982px ) {
+				margin-right: -1.5em;
+			}
 		}
 	}
 


### PR DESCRIPTION
Below 982px Vector uses 1em content padding instead of 1.5em