### PR TITLE
Fix a bug with pages that have multiple .mw-parser-output

### DIFF
--- a/src/Controller.js
+++ b/src/Controller.js
@@ -144,7 +144,7 @@ class Controller {
 				// This is due to VE replacing the content element,
 				// rather than inserting new contents into it.
 				// eslint-disable-next-line no-jquery/no-global-selector
-				this.model.initialize( $( '.mw-parser-output' ), config );
+				this.model.initialize( $( '#bodyContent .mw-parser-output' ), config );
 				this.model.toggleEnabled( true );
 			} );
 

--- a/src/outputs/browserextension.js
+++ b/src/outputs/browserextension.js
@@ -88,7 +88,7 @@ config.outputEnvironment = 'Browser extension';
 		loadWhoWroteThat = () => {
 			wwtController.initialize(
 				// eslint-disable-next-line no-jquery/no-global-selector
-				$( '.mw-parser-output' ),
+				$( '#bodyContent .mw-parser-output' ),
 				{
 					lang: mw.config.get( 'wgUserLanguage' ),
 					translations: languageBlob,


### PR DESCRIPTION
right now when this app replaces the page content (when enabling the plugin on a wikipedia page in the left nav) it searches for a `.mw-parser-output` class. usually there is only one of those classes present on the page around the primary page contents, however for pages that have `.mw-indicators` (icons for things such as "this page is protected") those icons are also wrapped in `.mw-parser-output`. the app currently treats every `.mw-parser-output` as a content wrapper so if you have two indicators when the page is re-appended to the wrapper it will write three copies of the page contents to the page.

example page with this bug: https://en.wikipedia.org/wiki/Bill_Gates

a side-effect of this bug (besides having the page display multiple times) is that the hovering effects will only apply to the last copy of the page contents. so if the page contents are written three times you need to scroll to the last copy of the page contents for the hover effects to work.