### PR TITLE
Fix Vector 2022 sticky header overlapping info bar

### DIFF
--- a/src/InfoBarWidget.js
+++ b/src/InfoBarWidget.js
@@ -44,6 +44,7 @@ const InfoBarWidget = function InfoBarWidget( config = {} ) {
 	// Initialize
 	this.$element
 		.addClass( 'wwt-infoBarWidget' )
+		.addClass( 'mw-sticky-header-element' ) // T310424
 		.append(
 			this.$pendingAnimation,
 			this.$icon,


### PR DESCRIPTION
Fix Vector 2022 sticky header overlapping the info bar following instructions at https://www.mediawiki.org/wiki/Reading/Web/Desktop_Improvements/Features/Sticky_Header#My_templates_use_sticky_elements._How_do_make_sure_they_do_not_overlap_the_sticky_header?

Bug: T310424