### PR TITLE
Prepare 0.20.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2023-10-30
+### Changed
+- Translation updates.
+
+### Fixed
+- Fix typo that loads messages when popup is requested
+- Fix Vector 2022 sticky header overlapping info bar
+
 ## [0.19.0] - 2023-06-06
 ### Changed
 - Added support for Hungarian, Indonesian, Japanese, Dutch, Polish and
@@ -190,7 +198,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First tagged release
 - Internationalization improvements
 
-[Unreleased]: https://github.com/wikimedia/WhoWroteThat/compare/0.19.0...HEAD
+[Unreleased]: https://github.com/wikimedia/WhoWroteThat/compare/0.20.0...HEAD
+[0.20.0]: https://github.com/wikimedia/WhoWroteThat/compare/0.19.0...0.20.0
 [0.19.0]: https://github.com/wikimedia/WhoWroteThat/compare/0.18.0...0.19.0
 [0.18.0]: https://github.com/wikimedia/WhoWroteThat/compare/0.17.0...0.18.0
 [0.17.0]: https://github.com/wikimedia/WhoWroteThat/compare/0.16.2...0.17.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-   "version": "0.19.0",
+   "version": "0.20.0",
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "repository": "https://github.com/wikimedia/WhoWroteThat",
-   "version": "0.19.0",
+   "version": "0.20.0",
    "license": "MIT",
    "webExt": {
       "sourceDir": "dist/extension/",


### PR DESCRIPTION
Version 0.20.0 was tagged on 6fe078b

This commit merely updates the CHANGELOG and bumps the version in package.json