### PR TITLE
Encode article title in WikiWho API access

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -126,7 +126,7 @@ class Api {
 			this.url,
 			subdomain,
 			'whocolor/v1.0.0-beta',
-			this.mwConfig.get( 'wgPageName' ),
+			encodeURIComponent( this.mwConfig.get( 'wgPageName' ) ),
 			// Always include the revision ID, to make sure we are always asking for
 			// the correct revision, whether the page was just edited, or, whether the
 			// page was edited by someone else while we were looking at the current page

--- a/test/suite/Api.test.js
+++ b/test/suite/Api.test.js
@@ -12,7 +12,7 @@ describe( 'Api test', () => {
 					wgRevisionId: 234,
 					wgPageName: 'Iñtërnâtiônàlizætiøn_(disambig)'
 				},
-				expected: 'https://wikiwho.example.com/en/whocolor/v1.0.0-beta/Iñtërnâtiônàlizætiøn_(disambig)/234/'
+				expected: 'https://wikiwho.example.com/en/whocolor/v1.0.0-beta/I%C3%B1t%C3%ABrn%C3%A2ti%C3%B4n%C3%A0liz%C3%A6ti%C3%B8n_(disambig)/234/'
 			},
 			{
 				msg: 'Should only append a revision ID if it is not the current one',
@@ -32,6 +32,15 @@ describe( 'Api test', () => {
 					wgCurRevisionId: 456
 				},
 				expected: 'https://wikiwho.example.com/ru/whocolor/v1.0.0-beta/Foo/123/'
+			},
+			{
+				msg: 'Should encode query parameters',
+				config: {
+					wgServerName: 'en.wikipedia.org',
+					wgRevisionId: 123,
+					wgPageName: 'Test Works?user-ip=0.0.0.0&'
+				},
+				expected: 'https://wikiwho.example.com/en/whocolor/v1.0.0-beta/Test%20Works%3Fuser-ip%3D0.0.0.0%26/123/'
 			}
 		];
 


### PR DESCRIPTION
The article title is not URL encoded when the WikiWho API URL is being constructed ([Api.js#getAjaxURL](https://github.com/wikimedia/WhoWroteThat/blob/b46af9f/src/Api.js#L129)). This causes any article with a question mark to have a URL containing query parameters starting wherever the question mark is.

Most prominent issue is when viewing an article with a title that ends with a question mark, where the title without the question mark removed (practically always a redirect) shows up instead of the actual article.
| **Before** | **After** |
:---:|:---:
![image](https://github.com/wikimedia/WhoWroteThat/assets/12129227/5f688117-7561-4ca6-aa8c-e64403b41e7e) | ![Screen Shot 2024-04-01 at 23 40 37](https://github.com/wikimedia/WhoWroteThat/assets/12129227/b47d5655-1c2c-4c74-861a-3b53e8011c73)

Revision ID left unencoded since it's expected to be a number, which won't have any special characters that need encoding.

*Initially reported by [Your Power](https://en.wikipedia.org/wiki/User:Your_Power) on Discord.*