### PR TITLE
Controller: remove use of mw.Uri which is deprecated, release 0.22.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.3] - 2025-05-16
+### Changed
+- Translation updates.
+### Fixed
+- Remove use of the deprecated mw.Uri module
+
 ## [0.22.2] - 2024-08-07
 ### Changed
 - Upgraded to manifest version 3.
@@ -219,7 +225,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First tagged release
 - Internationalization improvements
 
-[Unreleased]: https://github.com/wikimedia/WhoWroteThat/compare/0.22.2...HEAD
+[Unreleased]: https://github.com/wikimedia/WhoWroteThat/compare/0.22.3...HEAD
+[0.22.3]: https://github.com/wikimedia/WhoWroteThat/compare/0.22.2...0.22.3
 [0.22.2]: https://github.com/wikimedia/WhoWroteThat/compare/0.22.1...0.22.2
 [0.22.1]: https://github.com/wikimedia/WhoWroteThat/compare/0.22.0...0.22.1
 [0.22.0]: https://github.com/wikimedia/WhoWroteThat/compare/0.21.0...0.22.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
    "name": "WhoWroteThat",
-   "version": "0.21.1",
+   "version": "0.22.3",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
-         "version": "0.21.1",
+         "version": "0.22.3",
          "license": "MIT",
          "dependencies": {
             "@babel/polyfill": "^7.12.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "repository": "https://github.com/wikimedia/WhoWroteThat",
-   "version": "0.22.2",
+   "version": "0.22.3",
    "license": "MIT",
    "webExt": {
       "sourceDir": "dist/extension/",

--- a/src/Controller.js
+++ b/src/Controller.js
@@ -91,8 +91,7 @@ class Controller {
 	 *  of the wiki. Falls back to reading directly from mw.config
 	 */
 	initialize( $content, config ) {
-		let uri,
-			veLoading = false;
+		let veLoading = false;
 
 		if ( this.model.isInitialized() ) {
 			return;
@@ -109,8 +108,6 @@ class Controller {
 		// whether messages are set properly, since that
 		// has its own tests in the mw.messsages bundle
 		if ( window.mw ) {
-			uri = new mw.Uri();
-
 			this.api = new Api( {
 				url: config.wikiWhoUrl,
 				mwApi: new mw.Api(),
@@ -150,18 +147,16 @@ class Controller {
 
 			this.initialized = true;
 
-			// Mark as enabled after initialization, only if ve is not activated
+			const queryString = new URLSearchParams( window.location.search );
+			// Mark as enabled after initialization, only if ve is not activated.
 			// This is specifically for the case where we load the page with VE
 			// in the process of loading. In that case, if we leave VE after it
 			// loaded, the events above will trigger a change in the enabled state
 			// eslint-disable-next-line no-jquery/no-class-state
 			veLoading = $( document.documentElement ).hasClass( 've-activated' ) ||
 				(
-					uri &&
-						(
-							uri.query.veaction === 'edit' ||
-							uri.query.action === 'edit'
-						)
+					queryString.get( 'veaction' ) === 'edit' ||
+					queryString.get( 'action' ) === 'edit'
 				);
 
 			this.model.toggleEnabled( !veLoading );


### PR DESCRIPTION
Apparently something else that's loaded on every page recently stopped requiring mediawiki.Uri as a dependency, and thus our code would error out. mw.Uri is deprecated anyway (T374314), so switch to using URLSearchParams which is widely supported.

We could use mw.util.getParamValue() but that is also redundant to URLSearchParams and may also eventually be deprecated.

Bug: T394517